### PR TITLE
Update CI for publishing under the NPM maplibre org

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,4 +20,4 @@ jobs:
       - run: npm run build
       - run: npm publish dist/ngx-maplibre-gl
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NODE_AUTH_TOKEN: ${{secrets.NPM_ORG_TOKEN}}

--- a/projects/ngx-maplibre-gl/package.json
+++ b/projects/ngx-maplibre-gl/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ngx-maplibre-gl",
+  "name": "@maplibre/ngx-maplibre-gl",
   "version": "12.0.0",
   "description": "A Angular binding of maplibre-gl",
   "license": "MIT",


### PR DESCRIPTION
Please see https://github.com/maplibre/maplibre-gl-js/pull/231

@nyurik please share the organization secret `NPM_ORG_TOKEN` with this repository. Thank you!