### PR TITLE
decoupling test (language-switch) from testing framework (cypress)

### DIFF
--- a/projects/showcase/cypress/e2e/language-switch.cy.ts
+++ b/projects/showcase/cypress/e2e/language-switch.cy.ts
@@ -1,20 +1,25 @@
-import { E2eDriver } from './driver';
+import { E2eDriver } from '../support/e2e-driver';
 
 describe('Language switch', () => {
   let driver = new E2eDriver();
+
+  beforeEach(() => {
+    driver.when
+      .visit('/demo/language-switch')
+      .when.wait(2000)
+      .when.clickLanguageButton('French')
+      .when.waitForLanguageToChange()
+      .when.clickLanguageButton('French')
+      .when.waitForLanguageToChange()
+      .when.takeImageSnapshot()
+      .when.clickLanguageButton('Russian')
+      .when.waitForLanguageToChange();
+  });
+
   it('should change language', () => {
-    cy.visit('/demo/language-switch');
-    cy.wait(2000);
-    cy.get('.lang-button').contains('French').click();
-    cy.wait(5000);
-    cy.get('.lang-button').contains('French').click();
-    cy.wait(7000);
-    driver.initReferenceImage();
-    cy.get('.lang-button').contains('Russian').click();
-    cy.wait(7000); // wait for language to change
-    driver.compareToReference().should('be.greaterThan', 0);
-    cy.get('.lang-button').contains('French').click();
-    cy.wait(7000); // wait for language to change
-    driver.compareToReference().should('equal', 0);
+    expect(driver.get.isCurrentImageEqualToSnapshot());
+
+    driver.when.clickLanguageButton('French').when.waitForLanguageToChange();
+    expect(driver.get.isCurrentImageEqualToSnapshot());
   });
 });

--- a/projects/showcase/cypress/e2e/language-switch.cy.ts
+++ b/projects/showcase/cypress/e2e/language-switch.cy.ts
@@ -9,8 +9,6 @@ describe('Language switch', () => {
       .when.wait(2000)
       .when.clickLanguageButton('French')
       .when.waitForLanguageToChange()
-      .when.clickLanguageButton('French')
-      .when.waitForLanguageToChange()
       .when.takeImageSnapshot()
       .when.clickLanguageButton('Russian')
       .when.waitForLanguageToChange();

--- a/projects/showcase/cypress/support/e2e-driver.ts
+++ b/projects/showcase/cypress/support/e2e-driver.ts
@@ -1,0 +1,65 @@
+/// <reference types="cypress" />
+import pixelmatch from 'pixelmatch';
+import { PNG } from 'pngjs';
+
+export class E2eDriver {
+  private width: number;
+  private height: number;
+  private referenceImageBuffer: Buffer;
+
+  given = {};
+
+  when = {
+    visit: (url: string): E2eDriver => {
+      cy.visit(url);
+      return this;
+    },
+    wait: (ms: number): E2eDriver => {
+      cy.wait(ms);
+      return this;
+    },
+    waitForLanguageToChange: (): E2eDriver => this.when.wait(7000),
+    clickLanguageButton: (language: string): E2eDriver => {
+      cy.get('.lang-button').contains(language).click();
+      return this;
+    },
+    takeImageSnapshot: (): E2eDriver => {
+      this.initReferenceImage();
+      return this;
+    },
+  };
+
+  get = {
+    isCurrentImageEqualToSnapshot: () => this.compareToReference(),
+  };
+
+  private toImageBitmapBuffer(canvas: HTMLCanvasElement) {
+    const base64 = canvas.toDataURL('image/png').replace(/data:.*;base64,/, '');
+    const buff = Cypress.Buffer.from(base64, 'base64');
+    const png = PNG.sync.read(buff as any);
+    return png.data;
+  }
+
+  private initReferenceImage() {
+    return cy
+      .get('canvas')
+      .then((c) => {
+        this.width = c[0].width;
+        this.height = c[0].height;
+        this.referenceImageBuffer = this.toImageBitmapBuffer(c[0]);
+      })
+      .should('not.be.null');
+  }
+
+  private compareToReference() {
+    return cy.get('canvas').then((c) => {
+      return pixelmatch(
+        this.referenceImageBuffer,
+        this.toImageBitmapBuffer(c[0]),
+        null,
+        this.width,
+        this.height
+      );
+    });
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,5 +28,6 @@
         "name": "typescript-tslint-plugin"
       }
     ]
-  }
+  },
+  "exclude": ["**/cypress*.config.ts", "**/cypress"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,5 @@
         "name": "typescript-tslint-plugin"
       }
     ]
-  },
-  "exclude": ["**/cypress*.config.ts", "**/cypress"]
+  }
 }


### PR DESCRIPTION
Added e2e driver for complete decoupling between test (language-switch) and test framework (cypress), and for test readability.