### PR TITLE
Update version of cypress

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "@typescript-eslint/parser": "^5.36.2",
         "angular-cli-ghpages": "^0.6.0",
         "commitizen": "^4.2.5",
-        "cypress": "*",
+        "cypress": "^12.3.0",
         "cz-conventional-changelog": "^3.1.0",
         "eslint": "^8.23.0",
         "husky": "^4.2.1",
@@ -7289,9 +7289,9 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.10.0.tgz",
-      "integrity": "sha512-bU8r44x1NIYAUNNXt3CwJpLOVth7HUv2hUhYCxZmgZ1IugowDvuHNpevnoZRQx1KKOEisLvIJW+Xen5Pjn41pg==",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
+      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -7342,7 +7342,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
       }
     },
     "node_modules/cypress/node_modules/@types/node": {
@@ -25028,9 +25028,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.10.0.tgz",
-      "integrity": "sha512-bU8r44x1NIYAUNNXt3CwJpLOVth7HUv2hUhYCxZmgZ1IugowDvuHNpevnoZRQx1KKOEisLvIJW+Xen5Pjn41pg==",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
+      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@typescript-eslint/parser": "^5.36.2",
     "angular-cli-ghpages": "^0.6.0",
     "commitizen": "^4.2.5",
-    "cypress": "latest",
+    "cypress": "^12.3.0",
     "cz-conventional-changelog": "^3.1.0",
     "eslint": "^8.23.0",
     "husky": "^4.2.1",


### PR DESCRIPTION
Update version of Cypress. This should (hopefully?) upgrade the CI environment to use 12.x instead of 10.x when it runs `npm ci`.