### PR TITLE
Expose MapLIbre-GL 3D Terrain functionality

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -68,6 +68,7 @@ Dynamic:
 - [ngx] **panToOptions** Options passed to panTo (https://maplibre.org/maplibre-gl-js-docs/api/map/#map#panto)
 - [ngx] **centerWithPanTo**: `boolean` If set to true, then [panTo](https://maplibre.org/maplibre-gl-js-docs/api/map/#map#panto) is used instead of the specified method in **movingMethod** (if only **center** is changed, see live-update-feature example)
 - [ngx] **cursorStyle**: `string` change the cursor of the map canvas (`canvas.style.cursor`).
+- [ngx] **terrain**: `TerrainSpecification` (requires a raster DEM source, defined either via the `style` or a `mgl-raster-dem-source`).
 
 ### Outputs
 
@@ -265,6 +266,25 @@ Dynamic:
 - [**maxzoom**](https://www.mapbox.com/mapbox-gl-js/style-spec/#sources-raster-maxzoom): `number`
 - [**tileSize**](https://www.mapbox.com/mapbox-gl-js/style-spec/#sources-raster-tileSize): `number`
 
+## mgl-raster-dem-source [Mapbox GL style spec](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#raster-dem)
+
+### Inputs
+
+Init only:
+
+- **id**: `string` _(Required)_
+
+Dynamic:
+
+- [**url**](https://maplibre.org/maplibre-gl-js-docs/style-spec/sources/#raster-dem-url): `string`
+- [**tiles**](https://maplibre.org/maplibre-gl-js-docs/style-spec/sources/#raster-dem-tiles): `string[]`
+- [**bounds**](https://maplibre.org/maplibre-gl-js-docs/style-spec/sources/#raster-dem-bounds): `number[]`
+- [**minzoom**](https://maplibre.org/maplibre-gl-js-docs/style-spec/sources/#raster-dem-minzoom): `number`
+- [**maxzoom**](https://maplibre.org/maplibre-gl-js-docs/style-spec/sources/#raster-dem-maxzoom): `number`
+- [**tileSize**](https://maplibre.org/maplibre-gl-js-docs/style-spec/sources/#raster-dem-tileSize): `number`
+- [**attribution**](https://maplibre.org/maplibre-gl-js-docs/style-spec/sources/#raster-dem-attribution): `string`
+- [**encoding**](https://maplibre.org/maplibre-gl-js-docs/style-spec/sources/#raster-dem-encoding): `'mapbox' | 'terrarium'` _(Default: `'mapbox'`)_
+
 ## mgl-vector-source [Mapbox GL style spec](https://www.mapbox.com/mapbox-gl-js/style-spec/#sources-vector)
 
 ### Inputs
@@ -351,6 +371,12 @@ Dynamic:
   <mgl-control mglNavigation></mgl-control>
   ...
   <mgl-control mglScale unit="imperial" position="top-right"></mgl-control>
+  ...
+  <mgl-control
+    mglTerrain
+    source="rasterDemSource"
+    exaggeration="3.1"
+  ></mgl-control>
 </mgl-map>
 ```
 
@@ -359,19 +385,24 @@ Dynamic:
 Init only:
 
 - **position**: `'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'`
-- [**mglAttribution**](https://www.mapbox.com/mapbox-gl-js/api#attributioncontrol) \* **compact**: `boolean`
-- [**mglFullscreen**](https://www.mapbox.com/mapbox-gl-js/api/#fullscreencontrol)
-- [**mglGeolocate**](https://www.mapbox.com/mapbox-gl-js/api/#geolocatecontrol)
-  _ **positionOptions**: [`PositionOptions`](https://developer.mozilla.org/en-US/docs/Web/API/PositionOptions)
-  _ **fitBoundsOptions**: [`FitBoundsOptions`](https://www.mapbox.com/mapbox-gl-js/api/#map#fitbounds)
-  _ **trackUserLocation**: `boolean`
-  _ **showUserLocation**: `boolean`
-- [**mglNavigation**](https://www.mapbox.com/mapbox-gl-js/api/#navigationcontrol)
-  _ **showCompass**: `boolean`
-  _ **showZoom**: `boolean`
-- [**mglScale**](https://www.mapbox.com/mapbox-gl-js/api/#scalecontrol)
-  _ **maxWidth**: `number`
-  _ **unit**: `'imperial' | 'metric' | 'nautical'` (dynamic input)
+- [**mglAttribution**](https://maplibre.org/maplibre-gl-js-docs/api/markers/#attributioncontrol)
+  - **compact**: `boolean`
+- [**mglFullscreen**](https://maplibre.org/maplibre-gl-js-docs/api/markers/#fullscreencontrol)
+- [**mglGeolocate**](https://maplibre.org/maplibre-gl-js-docs/api/markers/#geolocatecontrol)
+  - **positionOptions**: [`PositionOptions`](https://developer.mozilla.org/en-US/docs/Web/API/PositionOptions)
+  - **fitBoundsOptions**: [`FitBoundsOptions`](https://maplibre.org/maplibre-gl-js-docs/api/map/#map#fitbounds)
+  - **trackUserLocation**: `boolean`
+  - **showUserLocation**: `boolean`
+- [**mglNavigation**](https://maplibre.org/maplibre-gl-js-docs/api/markers/#navigationcontrol)
+  - **showCompass**: `boolean`
+  - **showZoom**: `boolean`
+  - **visualizePitch**: `boolean`
+- [**mglScale**](https://maplibre.org/maplibre-gl-js-docs/api/markers/#scalecontrol)
+  - **maxWidth**: `number`
+  - **unit**: `'imperial' | 'metric' | 'nautical'` (dynamic input)
+- **mglTerrain**
+  - **source**: `string |`[`Source`](https://maplibre.org/maplibre-gl-js-docs/api/sources/) _(Note: a raster DEM Source)_
+  - **exaggeration**: `number` (1-100)
 
 ## mgl-marker [Mapbox GL API](https://www.mapbox.com/mapbox-gl-js/api/#marker)
 

--- a/projects/ngx-maplibre-gl/src/lib/control/navigation-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/navigation-control.directive.ts
@@ -10,6 +10,7 @@ export class NavigationControlDirective implements AfterContentInit {
   /* Init inputs */
   @Input() showCompass?: boolean;
   @Input() showZoom?: boolean;
+  @Input() visualizePitch?: boolean;
 
   constructor(
     private mapService: MapService,
@@ -21,13 +22,25 @@ export class NavigationControlDirective implements AfterContentInit {
       if (this.controlComponent.control) {
         throw new Error('Another control is already set for this control');
       }
-      const options: { showCompass?: boolean; showZoom?: boolean } = {};
+
+      const options: {
+        showCompass?: boolean;
+        showZoom?: boolean;
+        visualizePitch?: boolean;
+      } = {};
+
       if (this.showCompass !== undefined) {
         options.showCompass = this.showCompass;
       }
+
       if (this.showZoom !== undefined) {
         options.showZoom = this.showZoom;
       }
+
+      if (this.visualizePitch != undefined) {
+        options.visualizePitch = this.visualizePitch;
+      }
+
       this.controlComponent.control = new NavigationControl(options);
       this.mapService.addControl(
         this.controlComponent.control,

--- a/projects/ngx-maplibre-gl/src/lib/control/terrain-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/terrain-control.directive.ts
@@ -1,0 +1,38 @@
+import { AfterContentInit, Directive, Host, Input } from '@angular/core';
+import { TerrainControl, TerrainSpecification } from 'maplibre-gl';
+import { MapService } from '../map/map.service';
+import { ControlComponent } from './control.component';
+
+@Directive({
+  selector: '[mglTerrain]',
+})
+export class TerrainControlDirective implements AfterContentInit {
+  /* Init inputs */
+  @Input() source: string;
+  @Input() exaggeration?: number;
+
+  constructor(
+    private mapService: MapService,
+    @Host() private controlComponent: ControlComponent<TerrainControl>
+  ) {}
+
+  ngAfterContentInit() {
+    this.mapService.mapCreated$.subscribe(() => {
+      if (this.controlComponent.control) {
+        throw new Error('Another control is already set for this control');
+      }
+
+      const options: TerrainSpecification = {
+        source: this.source,
+        exaggeration: this.exaggeration ?? 1,
+      };
+
+      this.controlComponent.control = new TerrainControl(options);
+
+      this.mapService.addControl(
+        this.controlComponent.control,
+        this.controlComponent.position
+      );
+    });
+  }
+}

--- a/projects/ngx-maplibre-gl/src/lib/map/map.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/map/map.component.ts
@@ -26,6 +26,7 @@ import {
   MapTouchEvent,
   MapWheelEvent,
   PointLike,
+  TerrainSpecification,
 } from 'maplibre-gl';
 import { MapService, MovingOptions } from './map.service';
 import { MapEvent, EventData } from './map.types';
@@ -104,6 +105,8 @@ export class MapComponent
   /* Added by ngx-mapbox-gl */
   @Input() movingMethod: 'jumpTo' | 'easeTo' | 'flyTo' = 'flyTo';
   @Input() movingOptions?: MovingOptions;
+  @Input() terrain: TerrainSpecification;
+
   // => First value is a alias to bounds input (since mapbox 0.53.0). Subsequents changes are passed to fitBounds
   @Input() fitBounds?: LngLatBoundsLike;
   @Input() fitScreenCoordinates?: [PointLike, PointLike];
@@ -247,6 +250,7 @@ export class MapComponent
         antialias: this.antialias,
         locale: this.locale,
         cooperativeGestures: this.cooperativeGestures,
+        terrain: this.terrain,
       },
       mapEvents: this,
     });
@@ -371,6 +375,9 @@ export class MapComponent
         changes.bearing && this.bearing ? this.bearing[0] : undefined,
         changes.pitch && this.pitch ? this.pitch[0] : undefined
       );
+    }
+    if (changes.terrain && !changes.terrain.isFirstChange()) {
+      this.mapService.updateTerrain(changes.terrain.currentValue);
     }
   }
 }

--- a/projects/ngx-maplibre-gl/src/lib/map/map.service.ts
+++ b/projects/ngx-maplibre-gl/src/lib/map/map.service.ts
@@ -26,6 +26,7 @@ import {
   RasterLayerSpecification,
   CircleLayerSpecification,
   FilterSpecification,
+  TerrainSpecification,
 } from 'maplibre-gl';
 import { AsyncSubject, Observable, Subscription } from 'rxjs';
 import { first } from 'rxjs/operators';
@@ -41,6 +42,7 @@ export interface SetupMap {
     bearing?: [number];
     pitch?: [number];
     zoom?: [number];
+    terrain?: TerrainSpecification;
   };
   mapEvents: MapEvent;
 }
@@ -110,6 +112,12 @@ export class MapService {
       this.mapEvents = options.mapEvents;
       this.mapCreated.next(undefined);
       this.mapCreated.complete();
+
+      if (options.mapOptions.terrain) {
+        this.mapInstance.on('load', () => {
+          this.updateTerrain(options.mapOptions.terrain!);
+        });
+      }
     });
   }
 
@@ -223,6 +231,18 @@ export class MapService {
   updateMaxBounds(maxBounds: LngLatBoundsLike) {
     return this.zone.runOutsideAngular(() => {
       this.mapInstance.setMaxBounds(maxBounds);
+    });
+  }
+
+  updateTerrain(options: TerrainSpecification) {
+    return this.zone.runOutsideAngular(() => {
+      this.mapInstance.setTerrain(options);
+    });
+  }
+
+  getTerrain(): TerrainSpecification {
+    return this.zone.runOutsideAngular(() => {
+      return this.mapInstance.getTerrain();
     });
   }
 

--- a/projects/ngx-maplibre-gl/src/lib/ngx-maplibre-gl.module.ts
+++ b/projects/ngx-maplibre-gl/src/lib/ngx-maplibre-gl.module.ts
@@ -6,6 +6,7 @@ import { FullscreenControlDirective } from './control/fullscreen-control.directi
 import { GeolocateControlDirective } from './control/geolocate-control.directive';
 import { NavigationControlDirective } from './control/navigation-control.directive';
 import { ScaleControlDirective } from './control/scale-control.directive';
+import { TerrainControlDirective } from './control/terrain-control.directive';
 import { DraggableDirective } from './draggable/draggable.directive';
 import { ImageComponent } from './image/image.component';
 import { LayerComponent } from './layer/layer.component';
@@ -52,6 +53,7 @@ import { VideoSourceComponent } from './source/video-source.component';
     PointDirective,
     ClusterPointDirective,
     MarkersForClustersComponent,
+    TerrainControlDirective,
   ],
   exports: [
     MapComponent,
@@ -77,6 +79,7 @@ import { VideoSourceComponent } from './source/video-source.component';
     PointDirective,
     ClusterPointDirective,
     MarkersForClustersComponent,
+    TerrainControlDirective,
   ],
 })
 export class NgxMapLibreGLModule {}

--- a/projects/ngx-maplibre-gl/src/public_api.ts
+++ b/projects/ngx-maplibre-gl/src/public_api.ts
@@ -24,6 +24,7 @@ export * from './lib/control/navigation-control.directive';
 export * from './lib/control/attribution-control.directive';
 export * from './lib/control/scale-control.directive';
 export * from './lib/markers-for-clusters/markers-for-clusters.component';
+export * from './lib/control/terrain-control.directive';
 
 // Expose MapService for ngx-maplibre-gl extensions
 export * from './lib/map/map.service';

--- a/projects/showcase/cypress/e2e/terrain-control.cy.ts
+++ b/projects/showcase/cypress/e2e/terrain-control.cy.ts
@@ -1,0 +1,51 @@
+import { E2eDriver } from '../support/e2e-driver';
+
+describe('Terrain Control', () => {
+  context(
+    'Given I am on the Terrain Control showcase and Terrain is disabled',
+    () => {
+      let driver = new E2eDriver();
+
+      beforeEach(() => {
+        driver
+          .visitMapPage('/demo/terrain-control')
+          .waitForMapToIdle()
+          .assert.mapTerrainPropertyDoesNotExists()
+          .takeImageSnapshot();
+      });
+
+      context('When I click on the Terrain Control button once', () => {
+        beforeEach(() => {
+          // Enable Terrain
+          driver.when.clickEnableTerrainControlButton();
+        });
+
+        it('Then I should see the map image change and Terrain is enabled', () => {
+          driver
+            .waitForMapToIdle()
+            .assert.mapTerrainPropertyExists()
+            .assert.isNotSameAsSnapshot();
+        });
+      });
+
+      context('When I click on the Terrain Control button twice', () => {
+        beforeEach(() => {
+          // Enable Terrain
+          driver.when
+            .clickEnableTerrainControlButton()
+            .waitForMapToIdle()
+
+            // Disable Terrain
+            .when.clickDisableTerrainControlButton();
+        });
+
+        it('Then I should see the original map image and Terrain is disabled', () => {
+          driver
+            .waitForMapToIdle()
+            .assert.mapTerrainPropertyDoesNotExists()
+            .assert.isSameAsSnapshot();
+        });
+      });
+    }
+  );
+});

--- a/projects/showcase/cypress/support/e2e-driver.ts
+++ b/projects/showcase/cypress/support/e2e-driver.ts
@@ -95,6 +95,14 @@ export class E2eDriver {
       cy.get('.custom-control').click();
       return this;
     },
+    clickEnableTerrainControlButton: (): E2eDriver => {
+      cy.get('.maplibregl-ctrl-terrain').click();
+      return this;
+    },
+    clickDisableTerrainControlButton: (): E2eDriver => {
+      cy.get('.maplibregl-ctrl-terrain-enabled').click();
+      return this;
+    },
   };
 
   assert = {
@@ -135,6 +143,14 @@ export class E2eDriver {
         const zoom = win.mglMapTestHelper.map.getZoom();
         cy.wrap(zoom).should('be.lt', this.zoom);
       });
+      return this;
+    },
+    mapTerrainPropertyDoesNotExists: (): E2eDriver => {
+      cy.window().its('mglMapTestHelper.map.terrain').should('be.null');
+      return this;
+    },
+    mapTerrainPropertyExists: (): E2eDriver => {
+      cy.window().its('mglMapTestHelper.map.terrain').should('not.be.null');
       return this;
     },
     helloWorldPopupExists: (): E2eDriver => {

--- a/projects/showcase/src/app/demo/demo-index.component.ts
+++ b/projects/showcase/src/app/demo/demo-index.component.ts
@@ -52,6 +52,7 @@ export class DemoIndexComponent implements OnInit, AfterViewInit {
       Category.USER_INTERACTION,
       Category.CAMERA,
       Category.CONTROLS_AND_OVERLAYS,
+      Category.TERRAIN,
     ];
   }
 

--- a/projects/showcase/src/app/demo/demo.module.ts
+++ b/projects/showcase/src/app/demo/demo.module.ts
@@ -15,7 +15,6 @@ import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { RouterModule } from '@angular/router';
 import { NgxMapLibreGLModule } from 'projects/ngx-maplibre-gl/src/public_api';
-import { MapTestingHelperDirective } from '../helper/map-testing-helper.directive';
 import { LayoutModule } from '../shared/layout/layout.module';
 import { DemoIndexComponent } from './demo-index.component';
 import { Display3dBuildingsComponent } from './examples/3d-buildings.component';
@@ -66,6 +65,10 @@ import { ZoomtoLinestringComponent } from './examples/zoomto-linestring.componen
 import { MglMapResizeDirective } from './mgl-map-resize.directive';
 import { StackblitzEditGuard } from './stackblitz-edit/stackblitz-edit-guard.service';
 import { StackblitzEditComponent } from './stackblitz-edit/stackblitz-edit.component';
+import { TerrainMapStyleComponent } from './examples/terrain-map-style.component';
+import { TerrainMapComponent } from './examples/terrain-map.component';
+import { NgxTerrainSourceComponent } from './examples/ngx-terrain-control.component';
+import { MapTestingHelperDirective } from '../helper/map-testing-helper.directive';
 
 @NgModule({
   imports: [
@@ -73,11 +76,8 @@ import { StackblitzEditComponent } from './stackblitz-edit/stackblitz-edit.compo
     HttpClientModule,
     CommonModule,
     FormsModule,
-
     NgxMapLibreGLModule,
-
     LayoutModule,
-
     MatRadioModule,
     MatButtonToggleModule,
     MatButtonModule,
@@ -136,6 +136,9 @@ import { StackblitzEditComponent } from './stackblitz-edit/stackblitz-edit.compo
     CustomAttributionComponent,
     CustomLocaleComponent,
     MarkerAlignmentComponent,
+    TerrainMapStyleComponent,
+    TerrainMapComponent,
+    NgxTerrainSourceComponent,
     MapTestingHelperDirective,
   ],
   exports: [DemoIndexComponent],

--- a/projects/showcase/src/app/demo/examples/ngx-terrain-control.component.ts
+++ b/projects/showcase/src/app/demo/examples/ngx-terrain-control.component.ts
@@ -1,0 +1,36 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'showcase-demo',
+  template: `
+    <mgl-map
+      [style]="
+        'https://api.maptiler.com/maps/hybrid/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL'
+      "
+      [zoom]="[12]"
+      [center]="[11.39085, 47.27574]"
+      [pitch]="52"
+    >
+      <mgl-raster-dem-source
+        id="terrainSource"
+        url="https://demotiles.maplibre.org/terrain-tiles/tiles.json"
+        tileSize="256"
+      ></mgl-raster-dem-source>
+      <mgl-control
+        mglNavigation
+        showCompass="true"
+        showZoom="true"
+        visualizePitch="true"
+      ></mgl-control>
+      <mgl-control
+        mglTerrain
+        source="terrainSource"
+        exaggeration="5"
+        position="top-right"
+      ></mgl-control>
+    </mgl-map>
+  `,
+  styleUrls: ['./examples.css'],
+  preserveWhitespaces: false,
+})
+export class NgxTerrainSourceComponent {}

--- a/projects/showcase/src/app/demo/examples/terrain-map-style.component.ts
+++ b/projects/showcase/src/app/demo/examples/terrain-map-style.component.ts
@@ -1,0 +1,42 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'showcase-demo',
+  template: `
+    <mgl-map
+      [style]="{
+        version: 8,
+        sources: {
+          satelliteSource: {
+            tileSize: 512,
+            type: 'raster',
+            url:
+              'https://api.maptiler.com/tiles/satellite-v2/tiles.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL'
+          },
+          terrainSource: {
+            type: 'raster-dem',
+            url: 'https://demotiles.maplibre.org/terrain-tiles/tiles.json',
+            tileSize: 256
+          }
+        },
+        layers: [
+          {
+            id: 'satellite',
+            type: 'raster',
+            source: 'satelliteSource'
+          }
+        ],
+        terrain: {
+          source: 'terrainSource',
+          exaggeration: 1
+        }
+      }"
+      [zoom]="[12]"
+      [center]="[11.39085, 47.27574]"
+      [pitch]="52"
+    >
+    </mgl-map>
+  `,
+  styleUrls: ['./examples.css'],
+})
+export class TerrainMapStyleComponent {}

--- a/projects/showcase/src/app/demo/examples/terrain-map.component.ts
+++ b/projects/showcase/src/app/demo/examples/terrain-map.component.ts
@@ -1,0 +1,31 @@
+import { Component } from '@angular/core';
+import { TerrainSpecification } from 'maplibre-gl';
+
+@Component({
+  selector: 'showcase-demo',
+  template: `
+    <mgl-map
+      [style]="mapLibreExampleSource"
+      [zoom]="[12]"
+      [center]="[11.39085, 47.27574]"
+      [pitch]="52"
+      [terrain]="terrainSpec"
+    >
+      <mgl-raster-dem-source
+        id="terrainSource"
+        url="https://demotiles.maplibre.org/terrain-tiles/tiles.json"
+        tileSize="256"
+      ></mgl-raster-dem-source>
+    </mgl-map>
+  `,
+  styleUrls: ['./examples.css'],
+})
+export class TerrainMapComponent {
+  mapLibreExampleSource: string =
+    'https://api.maptiler.com/maps/hybrid/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL';
+
+  terrainSpec: TerrainSpecification = {
+    source: 'terrainSource',
+    exaggeration: 1,
+  };
+}

--- a/projects/showcase/src/app/demo/routes.ts
+++ b/projects/showcase/src/app/demo/routes.ts
@@ -31,12 +31,15 @@ import { NgxCustomMarkerIconsComponent } from './examples/ngx-custom-marker-icon
 import { NgxDragAPointComponent } from './examples/ngx-drag-a-point.component';
 import { NgxGeoJSONLineComponent } from './examples/ngx-geojson-line.component';
 import { NgxScaleControlComponent } from './examples/ngx-scale-control.component';
+import { NgxTerrainSourceComponent } from './examples/ngx-terrain-control.component';
 import { PolygonPopupOnClickComponent } from './examples/polygon-popup-on-click.component';
 import { PopupOnClickComponent } from './examples/popup-on-click.component';
 import { PopupComponent } from './examples/popup.component';
 import { SatelliteMapComponent } from './examples/satellite-map.component';
 import { SetPopupComponent } from './examples/set-popup.component';
 import { SetStyleComponent } from './examples/set-style.component';
+import { TerrainMapStyleComponent } from './examples/terrain-map-style.component';
+import { TerrainMapComponent } from './examples/terrain-map.component';
 import { ToggleLayersComponent } from './examples/toggle-layers.component';
 import { ZoomtoLinestringComponent } from './examples/zoomto-linestring.component';
 import { StackblitzEditGuard } from './stackblitz-edit/stackblitz-edit-guard.service';
@@ -49,6 +52,7 @@ export enum Category {
   USER_INTERACTION = 'User interaction',
   CAMERA = 'Camera',
   CONTROLS_AND_OVERLAYS = 'Controls and overlays',
+  TERRAIN = '3D Terrain',
 }
 
 export const DEMO_ROUTES: Routes = [
@@ -330,6 +334,30 @@ export const DEMO_ROUTES: Routes = [
         path: 'marker-alignment',
         component: MarkerAlignmentComponent,
         data: { label: 'Marker alignment options', cat: Category.CAMERA },
+      },
+      {
+        path: 'terrain-style',
+        component: TerrainMapStyleComponent,
+        data: {
+          label: 'Initialize 3D Terrain using style',
+          cat: Category.TERRAIN,
+        },
+      },
+      {
+        path: 'terrain-control',
+        component: NgxTerrainSourceComponent,
+        data: {
+          label: 'Terrain Control',
+          cat: Category.TERRAIN,
+        },
+      },
+      {
+        path: 'terrain',
+        component: TerrainMapComponent,
+        data: {
+          label: '[NGX] Initialize 3D Terrain declaratively',
+          cat: Category.TERRAIN,
+        },
       },
       { path: '**', redirectTo: 'display-map' },
     ],


### PR DESCRIPTION
Expose the 3D Terrain functionality from maplibre-gl (first seen in version [v.2.2.0](https://github.com/maplibre/maplibre-gl-js/releases/tag/v2.2.0))