### PR TITLE
Control removal fix

### DIFF
--- a/projects/ngx-maplibre-gl/src/lib/control/control.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/control.component.ts
@@ -34,8 +34,6 @@ export class CustomControl implements IControl {
 })
 export class ControlComponent<T extends IControl>
   implements OnDestroy, AfterContentInit {
-  private controlAdded = false;
-
   /* Init inputs */
   @Input() position?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 
@@ -50,13 +48,12 @@ export class ControlComponent<T extends IControl>
       this.control = new CustomControl(this.content.nativeElement);
       this.mapService.mapCreated$.subscribe(() => {
         this.mapService.addControl(this.control!, this.position);
-        this.controlAdded = true;
       });
     }
   }
 
   ngOnDestroy() {
-    if (this.controlAdded) {
+    if (this.mapService.mapInstance.hasControl(this.control)) {
       this.mapService.removeControl(this.control);
     }
   }

--- a/projects/showcase/cypress/e2e/ngx-custom-control.cy.ts
+++ b/projects/showcase/cypress/e2e/ngx-custom-control.cy.ts
@@ -17,5 +17,15 @@ describe('Custom control', () => {
         driver.assert.customPopupContainsHello();
       });
     });
+
+    context('When I click on the "Hide Controls" button', () => {
+      beforeEach(() => {
+        driver.assert.fullscreenControlExists().assert.customHelloButtonExists().when.clickHideControlsButton();
+      });
+
+      it('Then I should not see any controls anymore', () => {
+        driver.assert.fullscreenControlDoesNotExist().assert.customHelloButtonDoesNotExist()
+      });
+    });
   });
 });

--- a/projects/showcase/cypress/support/e2e-driver.ts
+++ b/projects/showcase/cypress/support/e2e-driver.ts
@@ -103,6 +103,10 @@ export class E2eDriver {
       cy.get('.maplibregl-ctrl-terrain-enabled').click();
       return this;
     },
+    clickHideControlsButton: (): E2eDriver => {
+      cy.get('button').contains('Hide Controls').click();
+      return this;
+    },
   };
 
   assert = {
@@ -168,6 +172,18 @@ export class E2eDriver {
     },
     customHelloButtonExists: (): E2eDriver => {
       cy.get('.custom-control').should('have.text', ' Hello ');
+      return this;
+    },
+    customHelloButtonDoesNotExist: (): E2eDriver => {
+      cy.get('.custom-control').should('not.exist');
+      return this;
+    },
+    fullscreenControlExists: (): E2eDriver => {
+      cy.get('.maplibregl-ctrl-fullscreen').should('exist');
+      return this;
+    },
+    fullscreenControlDoesNotExist: (): E2eDriver => {
+      cy.get('.maplibregl-ctrl-fullscreen').should('not.exist');
       return this;
     },
     customPopupContainsHello: (): E2eDriver => {

--- a/projects/showcase/src/app/demo/examples/ngx-custom-control.component.ts
+++ b/projects/showcase/src/app/demo/examples/ngx-custom-control.component.ts
@@ -9,35 +9,51 @@ import { Position } from 'projects/ngx-maplibre-gl/src/public_api';
         'https://api.maptiler.com/maps/streets/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL'
       "
     >
-      <mgl-control>
+      <ng-container *ngIf="visible">
+        <mgl-control>
+          <button
+            mat-fab
+            color="primary"
+            class="custom-control"
+            (click)="alert('Hello')"
+          >
+            Hello
+          </button>
+        </mgl-control>
+        <mgl-control mglAttribution position="top-right"></mgl-control>
+        <mgl-control mglFullscreen position="top-right"></mgl-control>
+        <mgl-control
+          mglGeolocate
+          position="top-right"
+          (geolocate)="onGeolocate($event)"
+        ></mgl-control>
+        <mgl-control mglNavigation position="top-right"></mgl-control>
+        <mgl-control mglScale position="top-right"></mgl-control>
+      </ng-container>
+
+      <mgl-control position="bottom-right">
         <button
-          mat-fab
-          color="primary"
-          class="custom-control"
-          (click)="alert('Hello')"
+          mat-flat-button
+          color="accent"
+          (click)="toggleControls()"
         >
-          Hello
+          {{ visible ? 'Hide Controls' : 'Show Controls'}}
         </button>
       </mgl-control>
-
-      <mgl-control mglAttribution position="top-right"></mgl-control>
-      <mgl-control mglFullscreen position="top-right"></mgl-control>
-      <mgl-control
-        mglGeolocate
-        position="top-right"
-        (geolocate)="onGeolocate($event)"
-      ></mgl-control>
-      <mgl-control mglNavigation position="top-right"></mgl-control>
-      <mgl-control mglScale position="top-right"></mgl-control>
     </mgl-map>
   `,
   styleUrls: ['./examples.css'],
 })
 export class NgxCustomControlComponent {
+  visible = true;
+
   alert(message: string) {
     alert(message);
   }
   onGeolocate(position: Position) {
     console.log('geolocate', position);
+  }
+  toggleControls() {
+    this.visible = !this.visible;
   }
 }


### PR DESCRIPTION
This fixes an issue with controls sometimes not being removed from the map when the control component is destroyed. For more details see https://github.com/maplibre/ngx-maplibre-gl/issues/85.

For the purpose of testing I also modified the custom control example and added a button that adds/removes the controls from the map. The tests now verify that the controls are removed.