### PR TITLE
Popup moving change

### DIFF
--- a/projects/ngx-maplibre-gl/src/lib/popup/popup.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/popup/popup.component.ts
@@ -59,8 +59,7 @@ export class PopupComponent
 
   ngOnChanges(changes: SimpleChanges) {
     if (
-      (changes.lngLat && !changes.lngLat.isFirstChange()) ||
-      (changes.feature && !changes.feature.isFirstChange())
+      changes.feature && !changes.feature.isFirstChange()
     ) {
       const newlngLat = changes.lngLat
         ? this.lngLat!
@@ -74,6 +73,13 @@ export class PopupComponent
       );
       this.popupInstance = popupInstanceTmp;
     }
+
+    if (
+      changes.lngLat && !changes.lngLat.isFirstChange()
+    ) {
+      this.popupInstance!.setLngLat(this.lngLat!);
+    }
+
     if (changes.marker && !changes.marker.isFirstChange()) {
       const previousMarker: MarkerComponent = changes.marker.previousValue;
       if (previousMarker.markerInstance) {

--- a/projects/showcase/src/app/demo/examples/polygon-popup-on-click.component.ts
+++ b/projects/showcase/src/app/demo/examples/polygon-popup-on-click.component.ts
@@ -12,6 +12,7 @@ import { GeoJsonProperties } from 'geojson';
       [zoom]="[3]"
       [center]="[-100.04, 38.907]"
       [cursorStyle]="cursorStyle"
+      (mapClick)="onMapClick()"
     >
       <mgl-layer
         id="states-layer"
@@ -29,7 +30,11 @@ import { GeoJsonProperties } from 'geojson';
         (layerMouseLeave)="cursorStyle = ''"
         (layerClick)="onClick($event)"
       ></mgl-layer>
-      <mgl-popup *ngIf="selectedLngLat" [lngLat]="selectedLngLat">
+      <mgl-popup
+        *ngIf="selectedElement && selectedLngLat"
+        [lngLat]="selectedLngLat"
+        [closeOnClick]="false"
+      >
         <span [innerHTML]="selectedElement?.name"></span>
       </mgl-popup>
     </mgl-map>
@@ -37,12 +42,16 @@ import { GeoJsonProperties } from 'geojson';
   styleUrls: ['./examples.css'],
 })
 export class PolygonPopupOnClickComponent {
-  selectedElement: GeoJsonProperties;
+  selectedElement: GeoJsonProperties | null;
   selectedLngLat: LngLat;
   cursorStyle: string;
 
   onClick(evt: MapLayerMouseEvent) {
     this.selectedLngLat = evt.lngLat;
     this.selectedElement = evt.features![0].properties;
+  }
+
+  onMapClick() {
+    this.selectedElement = null;
   }
 }


### PR DESCRIPTION
This modifies what happens when the value of the `lngLat` input of a popup component changes. 

The current behavior is to remove the old popup and then create a new popup at the new location. I would argue that this isn't optimal and that simply calling `setLngLat` on the existing popup would be a better solution.

My thought is that it probably originally was done this way to make sure that the popup always is open when the input changes, overriding the `closeOnClick` behavior. Regardless, this can be seen as a breaking change with perhaps only a small benefit. I can understand if you don't want to include it. 

The benefit of the change is mainly performance.  For example, making a popup work as a tooltip by following the mouse is more feasible after this change.

I modified the polygon-popup-on-click example, as it partially was broken by the change. 