### PR TITLE
fix layout shift on mobile devices, move menu items to menu

### DIFF
--- a/projects/showcase/src/app/demo/demo-index.component.html
+++ b/projects/showcase/src/app/demo/demo-index.component.html
@@ -1,5 +1,5 @@
 <showcase-layout-toolbar-menu position="left">
-  <button class="menu-button" mat-button (click)="toggleSidenav()">
+  <button class="menu-button" mat-icon-button (click)="toggleSidenav()">
     <mat-icon>menu</mat-icon>
   </button>
 </showcase-layout-toolbar-menu>

--- a/projects/showcase/src/app/doc/doc.component.ts
+++ b/projects/showcase/src/app/doc/doc.component.ts
@@ -35,6 +35,10 @@ export const VERSIONS = ['main'];
         justify-content: center;
       }
 
+      mat-form-field {
+        width: 100px;
+      }
+
       markdown {
         margin: 8px;
         width: 60%;

--- a/projects/showcase/src/app/shared/layout/layout.component.ts
+++ b/projects/showcase/src/app/shared/layout/layout.component.ts
@@ -21,7 +21,6 @@ import { MatMenuModule } from '@angular/material/menu';
       </div>
       <div>
         <div id="layout-right-custom-items"></div>
-        <!-- <a mat-button href="https://github.com/maplibre/ngx-maplibre-gl"> </a> -->
         <a mat-icon-button href="https://github.com/maplibre/ngx-maplibre-gl">
           <mat-icon svgIcon="github"></mat-icon>
         </a>

--- a/projects/showcase/src/app/shared/layout/layout.component.ts
+++ b/projects/showcase/src/app/shared/layout/layout.component.ts
@@ -3,6 +3,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { RouterLink, RouterOutlet } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatMenuModule } from '@angular/material/menu';
 
 @Component({
   template: `
@@ -13,17 +14,31 @@ import { MatToolbarModule } from '@angular/material/toolbar';
           <mat-icon svgIcon="ngx-maplibre-gl"></mat-icon>
         </a>
         <a mat-button routerLink="/"> ngx-maplibre-gl </a>
-        <a mat-button routerLink="/demo"> Demo </a>
-        <a mat-button routerLink="/doc"> Documentation </a>
+        <div class="menu-items">
+          <a mat-button routerLink="/demo"> Demo </a>
+          <a mat-button routerLink="/doc"> Documentation </a>
+        </div>
       </div>
       <div>
         <div id="layout-right-custom-items"></div>
-        <a mat-button href="https://github.com/maplibre/ngx-maplibre-gl">
-          Github
-        </a>
+        <!-- <a mat-button href="https://github.com/maplibre/ngx-maplibre-gl"> </a> -->
         <a mat-icon-button href="https://github.com/maplibre/ngx-maplibre-gl">
           <mat-icon svgIcon="github"></mat-icon>
         </a>
+        <button
+          class="mobile-menu-button"
+          mat-icon-button
+          type="button"
+          aria-label="Mobile menu"
+          [matMenuTriggerFor]="mobileMenu"
+        >
+          <mat-icon>more_vert</mat-icon>
+        </button>
+
+        <mat-menu #mobileMenu="matMenu">
+          <a mat-menu-item routerLink="/demo"> Demo </a>
+          <a mat-menu-item routerLink="/doc"> Documentation </a>
+        </mat-menu>
       </div>
     </mat-toolbar>
     <router-outlet></router-outlet>
@@ -40,7 +55,7 @@ import { MatToolbarModule } from '@angular/material/toolbar';
       mat-toolbar {
         display: flex;
         justify-content: space-between;
-        padding: 0 16px 0 0;
+        padding: 0 8px 0 0;
       }
 
       div {
@@ -52,6 +67,20 @@ import { MatToolbarModule } from '@angular/material/toolbar';
       .menu-button {
         height: 100%;
       }
+
+      .menu-items {
+        display: none;
+      }
+
+      @media (min-width: 640px) {
+        .menu-items {
+          display: flex;
+        }
+
+        .mobile-menu-button {
+          display: none;
+        }
+      }
     `,
   ],
   standalone: true,
@@ -61,6 +90,7 @@ import { MatToolbarModule } from '@angular/material/toolbar';
     RouterLink,
     MatIconModule,
     RouterOutlet,
+    MatMenuModule,
   ],
 })
 export class LayoutComponent {}

--- a/projects/showcase/src/app/shared/layout/layout.component.ts
+++ b/projects/showcase/src/app/shared/layout/layout.component.ts
@@ -13,7 +13,7 @@ import { MatMenuModule } from '@angular/material/menu';
         <a mat-icon-button routerLink="/">
           <mat-icon svgIcon="ngx-maplibre-gl"></mat-icon>
         </a>
-        <a mat-button routerLink="/"> ngx-maplibre-gl </a>
+        <a mat-button routerLink="/" class="library-name"> ngx-maplibre-gl </a>
         <div class="menu-items">
           <a mat-button routerLink="/demo"> Demo </a>
           <a mat-button routerLink="/doc"> Documentation </a>
@@ -71,8 +71,16 @@ import { MatMenuModule } from '@angular/material/menu';
         display: none;
       }
 
+      .library-name {
+        display: none;
+      }
+
       @media (min-width: 640px) {
         .menu-items {
+          display: flex;
+        }
+
+        .library-name {
           display: flex;
         }
 


### PR DESCRIPTION
### Before

![CleanShot 2023-12-18 at 11 31 14](https://github.com/maplibre/ngx-maplibre-gl/assets/8985933/26b003dc-82da-4ae3-b56b-8e0fbae8bf0a)
![CleanShot 2023-12-18 at 11 31 19](https://github.com/maplibre/ngx-maplibre-gl/assets/8985933/ab320c08-e766-4b72-84a0-74ffe010c487)


### After

![CleanShot 2023-12-18 at 11 30 27](https://github.com/maplibre/ngx-maplibre-gl/assets/8985933/227079de-2f28-4ce5-9d2f-8aac800719fc)
![CleanShot 2023-12-18 at 11 32 04](https://github.com/maplibre/ngx-maplibre-gl/assets/8985933/c2be2567-7272-48f7-aa04-c7f2d05d7073)
