### PR TITLE
npm ci

### DIFF
--- a/.github/workflows/gh-pages-push.yml
+++ b/.github/workflows/gh-pages-push.yml
@@ -17,7 +17,7 @@ jobs:
       # Runs a set of commands using the runners shell
       - name: Install and build
         run: |
-          npm install
+          npm ci
           npm run build:showcase
           
       - name: Deploy 🚀

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           registry-url: https://registry.npmjs.org/
-      - run: npm install
+      - run: npm ci 
       - run: npm run build
       - run: |
           cd dist/ngx-maplibre-gl

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
     "**/.hg": true,
     "**/CVS": true,
     "**/.DS_Store": true,
+    "**/node_modules/**": true,
     ".ng_build": true
   },
   "typescript.tsdk": "node_modules/typescript/lib",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Install project dependencies (package.json)
 
 ```
-npm install
+npm ci
 ```
 
 ## Run ngx-maplibre-gl showcase


### PR DESCRIPTION
use `npm ci` instead of `npm install` for reproductive builds.