### PR TITLE
Migrate to typedoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Build showcase
         run: npm run build:showcase
 
+      - name: Build docs
+        run: npm run docs
+
       - name: Run unit tests
         run: npm run test -- ngx-maplibre-gl --watch=false --no-progress --browsers=ChromeHeadless
         

--- a/.github/workflows/gh-pages-push.yml
+++ b/.github/workflows/gh-pages-push.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
 
       # Runs a set of commands using the runners shell
@@ -19,6 +19,7 @@ jobs:
         run: |
           npm ci
           npm run build:showcase
+          npm run docs
           
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.4

--- a/angular.json
+++ b/angular.json
@@ -68,10 +68,7 @@
               "projects/showcase/src/app/demo/examples"
             ],
             "styles": ["projects/showcase/src/styles.css"],
-            "scripts": [
-              "node_modules/marked/marked.min.js",
-              "node_modules/prismjs/prism.js"
-            ]
+            "scripts": []
           },
           "configurations": {
             "production": {
@@ -123,10 +120,7 @@
             "tsConfig": "projects/showcase/tsconfig.spec.json",
             "karmaConfig": "projects/showcase/karma.conf.js",
             "styles": ["projects/showcase/src/styles.css"],
-            "scripts": [
-              "node_modules/marked/lib/marked.js",
-              "node_modules/prismjs/prism.js"
-            ],
+            "scripts": [],
             "assets": [
               "projects/showcase/src/favicon.ico",
               "projects/showcase/src/assets"

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "pngjs": "^7.0.0",
         "standard-version": "^9.5.0",
         "ts-node": "^10.9.1",
+        "typedoc": "^0.25.12",
         "typescript": "^5.2.2"
       },
       "engines": {
@@ -7012,6 +7013,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ansi-sequence-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
+      "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
+      "dev": true
     },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
@@ -16196,6 +16203,12 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "node_modules/magic-string": {
       "version": "0.30.5",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
@@ -20711,6 +20724,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/shiki": {
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
+      "integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -22158,6 +22183,63 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "dev": true
     },
+    "node_modules/typedoc": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.12.tgz",
+      "integrity": "sha512-F+qhkK2VoTweDXd1c42GS/By2DvI2uDF4/EpG424dTexSHdtCH52C6IcAvMA6jR3DzAWZjHpUOW+E02kyPNUNw==",
+      "dev": true,
+      "dependencies": {
+        "lunr": "^2.3.9",
+        "marked": "^4.3.0",
+        "minimatch": "^9.0.3",
+        "shiki": "^0.14.7"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
@@ -22981,6 +23063,18 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+      "dev": true
     },
     "node_modules/vt-pbf": {
       "version": "3.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "@stackblitz/sdk": "^1.9.0",
         "lodash-es": "^4.17.21",
         "maplibre-gl": "^4.0.0",
-        "ngx-markdown": "^17.1.1",
         "rxjs": "7.8.1",
         "scroll-into-view-if-needed": "^3.1.0",
         "tslib": "^2.6.2",
@@ -2613,12 +2612,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@braintree/sanitize-url": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.4.tgz",
-      "integrity": "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==",
-      "optional": true
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -5847,36 +5840,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/d3-scale": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
-      "integrity": "sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==",
-      "optional": true,
-      "dependencies": {
-        "@types/d3-time": "*"
-      }
-    },
-    "node_modules/@types/d3-scale-chromatic": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.0.2.tgz",
-      "integrity": "sha512-kpKNZMDT3OAX6b5ct5nS/mv6LULagnUy4DmS6yyNjclje1qVe7vbjPwY3q1TGz6+Wr2IUkgFatCzqYUl54fHag==",
-      "optional": true
-    },
-    "node_modules/@types/d3-time": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.3.tgz",
-      "integrity": "sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw==",
-      "optional": true
-    },
-    "node_modules/@types/debug": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
-      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
-      "optional": true,
-      "dependencies": {
-        "@types/ms": "*"
-      }
-    },
     "node_modules/@types/eslint": {
       "version": "8.44.7",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.7.tgz",
@@ -6006,15 +5969,6 @@
         "@types/pbf": "*"
       }
     },
-    "node_modules/@types/mdast": {
-      "version": "3.0.15",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.15.tgz",
-      "integrity": "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==",
-      "optional": true,
-      "dependencies": {
-        "@types/unist": "^2"
-      }
-    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -6026,12 +5980,6 @@
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
       "dev": true
-    },
-    "node_modules/@types/ms": {
-      "version": "0.7.34",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
-      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==",
-      "optional": true
     },
     "node_modules/@types/node": {
       "version": "20.9.2",
@@ -6168,12 +6116,6 @@
       "dependencies": {
         "@types/geojson": "*"
       }
-    },
-    "node_modules/@types/unist": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
-      "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==",
-      "optional": true
     },
     "node_modules/@types/ws": {
       "version": "8.5.9",
@@ -8111,16 +8053,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/character-entities": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
-      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
-      "optional": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
@@ -8267,17 +8199,6 @@
       "dev": true,
       "engines": {
         "node": ">= 12"
-      }
-    },
-    "node_modules/clipboard": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.11.tgz",
-      "integrity": "sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==",
-      "optional": true,
-      "dependencies": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
       }
     },
     "node_modules/cliui": {
@@ -9203,15 +9124,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/cose-base": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
-      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
-      "optional": true,
-      "dependencies": {
-        "layout-base": "^1.0.0"
-      }
-    },
     "node_modules/cosmiconfig": {
       "version": "8.3.6",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
@@ -9654,58 +9566,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/cytoscape": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.27.0.tgz",
-      "integrity": "sha512-pPZJilfX9BxESwujODz5pydeGi+FBrXq1rcaB1mfhFXXFJ9GjE6CNndAk+8jPzoXGD+16LtSS4xlYEIUiW4Abg==",
-      "optional": true,
-      "dependencies": {
-        "heap": "^0.2.6",
-        "lodash": "^4.17.21"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/cytoscape-cose-bilkent": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
-      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
-      "optional": true,
-      "dependencies": {
-        "cose-base": "^1.0.0"
-      },
-      "peerDependencies": {
-        "cytoscape": "^3.2.0"
-      }
-    },
-    "node_modules/cytoscape-fcose": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
-      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
-      "optional": true,
-      "dependencies": {
-        "cose-base": "^2.2.0"
-      },
-      "peerDependencies": {
-        "cytoscape": "^3.2.0"
-      }
-    },
-    "node_modules/cytoscape-fcose/node_modules/cose-base": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
-      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
-      "optional": true,
-      "dependencies": {
-        "layout-base": "^2.0.0"
-      }
-    },
-    "node_modules/cytoscape-fcose/node_modules/layout-base": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
-      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
-      "optional": true
-    },
     "node_modules/cz-conventional-changelog": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.3.0.tgz",
@@ -9724,478 +9584,6 @@
       },
       "optionalDependencies": {
         "@commitlint/load": ">6.1.1"
-      }
-    },
-    "node_modules/d3": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/d3/-/d3-7.8.5.tgz",
-      "integrity": "sha512-JgoahDG51ncUfJu6wX/1vWQEqOflgXyl4MaHqlcSruTez7yhaRKR9i8VjjcQGeS2en/jnFivXuaIMnseMMt0XA==",
-      "optional": true,
-      "dependencies": {
-        "d3-array": "3",
-        "d3-axis": "3",
-        "d3-brush": "3",
-        "d3-chord": "3",
-        "d3-color": "3",
-        "d3-contour": "4",
-        "d3-delaunay": "6",
-        "d3-dispatch": "3",
-        "d3-drag": "3",
-        "d3-dsv": "3",
-        "d3-ease": "3",
-        "d3-fetch": "3",
-        "d3-force": "3",
-        "d3-format": "3",
-        "d3-geo": "3",
-        "d3-hierarchy": "3",
-        "d3-interpolate": "3",
-        "d3-path": "3",
-        "d3-polygon": "3",
-        "d3-quadtree": "3",
-        "d3-random": "3",
-        "d3-scale": "4",
-        "d3-scale-chromatic": "3",
-        "d3-selection": "3",
-        "d3-shape": "3",
-        "d3-time": "3",
-        "d3-time-format": "4",
-        "d3-timer": "3",
-        "d3-transition": "3",
-        "d3-zoom": "3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "optional": true,
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-axis": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
-      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-brush": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
-      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
-      "optional": true,
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-drag": "2 - 3",
-        "d3-interpolate": "1 - 3",
-        "d3-selection": "3",
-        "d3-transition": "3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-chord": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
-      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
-      "optional": true,
-      "dependencies": {
-        "d3-path": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-contour": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
-      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
-      "optional": true,
-      "dependencies": {
-        "d3-array": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-delaunay": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
-      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
-      "optional": true,
-      "dependencies": {
-        "delaunator": "5"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-dispatch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
-      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-drag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
-      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
-      "optional": true,
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-selection": "3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-dsv": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
-      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
-      "optional": true,
-      "dependencies": {
-        "commander": "7",
-        "iconv-lite": "0.6",
-        "rw": "1"
-      },
-      "bin": {
-        "csv2json": "bin/dsv2json.js",
-        "csv2tsv": "bin/dsv2dsv.js",
-        "dsv2dsv": "bin/dsv2dsv.js",
-        "dsv2json": "bin/dsv2json.js",
-        "json2csv": "bin/json2dsv.js",
-        "json2dsv": "bin/json2dsv.js",
-        "json2tsv": "bin/json2dsv.js",
-        "tsv2csv": "bin/dsv2dsv.js",
-        "tsv2json": "bin/dsv2json.js"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-dsv/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "optional": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/d3-dsv/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "optional": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/d3-ease": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-fetch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
-      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
-      "optional": true,
-      "dependencies": {
-        "d3-dsv": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-force": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
-      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
-      "optional": true,
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-quadtree": "1 - 3",
-        "d3-timer": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-format": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-geo": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.0.tgz",
-      "integrity": "sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==",
-      "optional": true,
-      "dependencies": {
-        "d3-array": "2.5.0 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-hierarchy": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
-      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-      "optional": true,
-      "dependencies": {
-        "d3-color": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-polygon": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
-      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-quadtree": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
-      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-random": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
-      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-sankey": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
-      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
-      "optional": true,
-      "dependencies": {
-        "d3-array": "1 - 2",
-        "d3-shape": "^1.2.0"
-      }
-    },
-    "node_modules/d3-sankey/node_modules/d3-array": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
-      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
-      "optional": true,
-      "dependencies": {
-        "internmap": "^1.0.0"
-      }
-    },
-    "node_modules/d3-sankey/node_modules/d3-path": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
-      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
-      "optional": true
-    },
-    "node_modules/d3-sankey/node_modules/d3-shape": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
-      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
-      "optional": true,
-      "dependencies": {
-        "d3-path": "1"
-      }
-    },
-    "node_modules/d3-sankey/node_modules/internmap": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
-      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
-      "optional": true
-    },
-    "node_modules/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "optional": true,
-      "dependencies": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-scale-chromatic": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz",
-      "integrity": "sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==",
-      "optional": true,
-      "dependencies": {
-        "d3-color": "1 - 3",
-        "d3-interpolate": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-selection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-shape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "optional": true,
-      "dependencies": {
-        "d3-path": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-      "optional": true,
-      "dependencies": {
-        "d3-array": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-      "optional": true,
-      "dependencies": {
-        "d3-time": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-timer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-transition": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
-      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
-      "optional": true,
-      "dependencies": {
-        "d3-color": "1 - 3",
-        "d3-dispatch": "1 - 3",
-        "d3-ease": "1 - 3",
-        "d3-interpolate": "1 - 3",
-        "d3-timer": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "d3-selection": "2 - 3"
-      }
-    },
-    "node_modules/d3-zoom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
-      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
-      "optional": true,
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-drag": "2 - 3",
-        "d3-interpolate": "1 - 3",
-        "d3-selection": "2 - 3",
-        "d3-transition": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/dagre-d3-es": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.10.tgz",
-      "integrity": "sha512-qTCQmEhcynucuaZgY5/+ti3X/rnszKZhEQH/ZdWdtP1tA/y3VoHJzcVrO9pjjJCNpigfscAtoUB5ONcd2wNn0A==",
-      "optional": true,
-      "dependencies": {
-        "d3": "^7.8.2",
-        "lodash-es": "^4.17.21"
       }
     },
     "node_modules/dargs": {
@@ -10241,13 +9629,13 @@
       "version": "1.11.10",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
       "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -10292,19 +9680,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/decode-named-character-reference": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
-      "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
-      "optional": true,
-      "dependencies": {
-        "character-entities": "^2.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dedent": {
@@ -10419,15 +9794,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/delaunator": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.0.tgz",
-      "integrity": "sha512-AyLvtyJdbv/U1GkiS6gUUzclRoAY4Gs75qkMygJJhU75LW4DNuSF2RMzpxs9jw9Oz1BobHjTdkG3zdP55VxAqw==",
-      "optional": true,
-      "dependencies": {
-        "robust-predicates": "^3.0.0"
-      }
-    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -10436,12 +9802,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/delegate": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-      "optional": true
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -10465,7 +9825,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -10643,12 +10003,6 @@
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
-    },
-    "node_modules/dompurify": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.6.tgz",
-      "integrity": "sha512-ilkD8YEnnGh1zJ240uJsW7AzE+2qpbOUYjacomn3AvJ6J4JhKGSZ2nh4wUIXPZrEPppaCLx5jFe8T89Rk8tQ7w==",
-      "optional": true
     },
     "node_modules/domutils": {
       "version": "3.1.0",
@@ -10904,12 +10258,6 @@
       "integrity": "sha512-zF6y5v/YfoFIgwf2dDfAqVlPPsyQeWNpEWXbAlDUS8Ax4Z2VoiiZpAPC0Jm9hXEkJm2vIZpwB6rc4KnLTQffbQ==",
       "dev": true
     },
-    "node_modules/elkjs": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.8.2.tgz",
-      "integrity": "sha512-L6uRgvZTH+4OF5NE/MBbzQx/WYpru1xCBE9respNj6qznEewGUIfhzmm7horWWxbNO2M0WckQypGctR8lH79xQ==",
-      "optional": true
-    },
     "node_modules/email-addresses": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-3.1.0.tgz",
@@ -10921,12 +10269,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
-    },
-    "node_modules/emoji-toolkit": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-toolkit/-/emoji-toolkit-8.0.0.tgz",
-      "integrity": "sha512-Vz8YIqQJsQ+QZ4yuKMMzliXceayqfWbNjb6bST+vm77QAhU2is3I+/PRxrNknW+q1bvHHMgjLCQXxzINWLVapg==",
-      "optional": true
     },
     "node_modules/emojis-list": {
       "version": "3.0.0",
@@ -13057,15 +12399,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/good-listener": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-      "integrity": "sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==",
-      "optional": true,
-      "dependencies": {
-        "delegate": "^3.1.2"
-      }
-    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -13208,12 +12541,6 @@
       "resolved": "https://registry.npmjs.org/hdr-histogram-percentiles-obj/-/hdr-histogram-percentiles-obj-3.0.0.tgz",
       "integrity": "sha512-7kIufnBqdsBGcSZLPJwqHT3yhk1QTsSlFsVD3kx5ixH/AlgBs9yM1q6DPhXZ8f8gtdqgh7N7/5btRLpQsS2gHw==",
       "dev": true
-    },
-    "node_modules/heap": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.7.tgz",
-      "integrity": "sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==",
-      "optional": true
     },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
@@ -13724,15 +13051,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/internmap": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/ip": {
@@ -14983,31 +14301,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/katex": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.9.tgz",
-      "integrity": "sha512-fsSYjWS0EEOwvy81j3vRA8TEAhQhKiqO+FQaKWp0m39qwOzHVBgAUBIXWj1pB+O2W3fIpNa6Y9KSKCVbfPhyAQ==",
-      "funding": [
-        "https://opencollective.com/katex",
-        "https://github.com/sponsors/katex"
-      ],
-      "optional": true,
-      "dependencies": {
-        "commander": "^8.3.0"
-      },
-      "bin": {
-        "katex": "cli.js"
-      }
-    },
-    "node_modules/katex/node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "optional": true,
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/kdbush": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
@@ -15022,27 +14315,12 @@
         "json-buffer": "3.0.1"
       }
     },
-    "node_modules/khroma": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
-      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==",
-      "optional": true
-    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/kleur": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
-      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
-      "optional": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/klona": {
@@ -15063,12 +14341,6 @@
         "picocolors": "^1.0.0",
         "shell-quote": "^1.8.1"
       }
-    },
-    "node_modules/layout-base": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
-      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
-      "optional": true
     },
     "node_modules/lazy-ass": {
       "version": "1.6.0",
@@ -15951,7 +15223,7 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
@@ -16316,55 +15588,6 @@
         "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
       }
     },
-    "node_modules/marked": {
-      "version": "9.1.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
-      "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
-      "peer": true,
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 16"
-      }
-    },
-    "node_modules/mdast-util-from-markdown": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
-      "integrity": "sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==",
-      "optional": true,
-      "dependencies": {
-        "@types/mdast": "^3.0.0",
-        "@types/unist": "^2.0.0",
-        "decode-named-character-reference": "^1.0.0",
-        "mdast-util-to-string": "^3.1.0",
-        "micromark": "^3.0.0",
-        "micromark-util-decode-numeric-character-reference": "^1.0.0",
-        "micromark-util-decode-string": "^1.0.0",
-        "micromark-util-normalize-identifier": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0",
-        "unist-util-stringify-position": "^3.0.0",
-        "uvu": "^0.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-to-string": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
-      "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
-      "optional": true,
-      "dependencies": {
-        "@types/mdast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -16581,47 +15804,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/mermaid": {
-      "version": "10.6.1",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-10.6.1.tgz",
-      "integrity": "sha512-Hky0/RpOw/1il9X8AvzOEChfJtVvmXm+y7JML5C//ePYMy0/9jCEmW1E1g86x9oDfW9+iVEdTV/i+M6KWRNs4A==",
-      "optional": true,
-      "dependencies": {
-        "@braintree/sanitize-url": "^6.0.1",
-        "@types/d3-scale": "^4.0.3",
-        "@types/d3-scale-chromatic": "^3.0.0",
-        "cytoscape": "^3.23.0",
-        "cytoscape-cose-bilkent": "^4.1.0",
-        "cytoscape-fcose": "^2.1.0",
-        "d3": "^7.4.0",
-        "d3-sankey": "^0.12.3",
-        "dagre-d3-es": "7.0.10",
-        "dayjs": "^1.11.7",
-        "dompurify": "^3.0.5",
-        "elkjs": "^0.8.2",
-        "khroma": "^2.0.0",
-        "lodash-es": "^4.17.21",
-        "mdast-util-from-markdown": "^1.3.0",
-        "non-layered-tidy-tree-layout": "^2.0.2",
-        "stylis": "^4.1.3",
-        "ts-dedent": "^2.2.0",
-        "uuid": "^9.0.0",
-        "web-worker": "^1.2.0"
-      }
-    },
-    "node_modules/mermaid/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "optional": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -16630,448 +15812,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/micromark": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.2.0.tgz",
-      "integrity": "sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "optional": true,
-      "dependencies": {
-        "@types/debug": "^4.0.0",
-        "debug": "^4.0.0",
-        "decode-named-character-reference": "^1.0.0",
-        "micromark-core-commonmark": "^1.0.1",
-        "micromark-factory-space": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-chunked": "^1.0.0",
-        "micromark-util-combine-extensions": "^1.0.0",
-        "micromark-util-decode-numeric-character-reference": "^1.0.0",
-        "micromark-util-encode": "^1.0.0",
-        "micromark-util-normalize-identifier": "^1.0.0",
-        "micromark-util-resolve-all": "^1.0.0",
-        "micromark-util-sanitize-uri": "^1.0.0",
-        "micromark-util-subtokenize": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.1",
-        "uvu": "^0.5.0"
-      }
-    },
-    "node_modules/micromark-core-commonmark": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.1.0.tgz",
-      "integrity": "sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "optional": true,
-      "dependencies": {
-        "decode-named-character-reference": "^1.0.0",
-        "micromark-factory-destination": "^1.0.0",
-        "micromark-factory-label": "^1.0.0",
-        "micromark-factory-space": "^1.0.0",
-        "micromark-factory-title": "^1.0.0",
-        "micromark-factory-whitespace": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-chunked": "^1.0.0",
-        "micromark-util-classify-character": "^1.0.0",
-        "micromark-util-html-tag-name": "^1.0.0",
-        "micromark-util-normalize-identifier": "^1.0.0",
-        "micromark-util-resolve-all": "^1.0.0",
-        "micromark-util-subtokenize": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.1",
-        "uvu": "^0.5.0"
-      }
-    },
-    "node_modules/micromark-factory-destination": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.1.0.tgz",
-      "integrity": "sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "optional": true,
-      "dependencies": {
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "node_modules/micromark-factory-label": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.1.0.tgz",
-      "integrity": "sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "optional": true,
-      "dependencies": {
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0",
-        "uvu": "^0.5.0"
-      }
-    },
-    "node_modules/micromark-factory-space": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.1.0.tgz",
-      "integrity": "sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "optional": true,
-      "dependencies": {
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "node_modules/micromark-factory-title": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.1.0.tgz",
-      "integrity": "sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "optional": true,
-      "dependencies": {
-        "micromark-factory-space": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "node_modules/micromark-factory-whitespace": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.1.0.tgz",
-      "integrity": "sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "optional": true,
-      "dependencies": {
-        "micromark-factory-space": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "node_modules/micromark-util-character": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
-      "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "optional": true,
-      "dependencies": {
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "node_modules/micromark-util-chunked": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.1.0.tgz",
-      "integrity": "sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "optional": true,
-      "dependencies": {
-        "micromark-util-symbol": "^1.0.0"
-      }
-    },
-    "node_modules/micromark-util-classify-character": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.1.0.tgz",
-      "integrity": "sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "optional": true,
-      "dependencies": {
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "node_modules/micromark-util-combine-extensions": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.1.0.tgz",
-      "integrity": "sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "optional": true,
-      "dependencies": {
-        "micromark-util-chunked": "^1.0.0",
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "node_modules/micromark-util-decode-numeric-character-reference": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.1.0.tgz",
-      "integrity": "sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "optional": true,
-      "dependencies": {
-        "micromark-util-symbol": "^1.0.0"
-      }
-    },
-    "node_modules/micromark-util-decode-string": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.1.0.tgz",
-      "integrity": "sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "optional": true,
-      "dependencies": {
-        "decode-named-character-reference": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-decode-numeric-character-reference": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0"
-      }
-    },
-    "node_modules/micromark-util-encode": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.1.0.tgz",
-      "integrity": "sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "optional": true
-    },
-    "node_modules/micromark-util-html-tag-name": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.2.0.tgz",
-      "integrity": "sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "optional": true
-    },
-    "node_modules/micromark-util-normalize-identifier": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.1.0.tgz",
-      "integrity": "sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "optional": true,
-      "dependencies": {
-        "micromark-util-symbol": "^1.0.0"
-      }
-    },
-    "node_modules/micromark-util-resolve-all": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.1.0.tgz",
-      "integrity": "sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "optional": true,
-      "dependencies": {
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "node_modules/micromark-util-sanitize-uri": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.2.0.tgz",
-      "integrity": "sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "optional": true,
-      "dependencies": {
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-encode": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0"
-      }
-    },
-    "node_modules/micromark-util-subtokenize": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.1.0.tgz",
-      "integrity": "sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "optional": true,
-      "dependencies": {
-        "micromark-util-chunked": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0",
-        "uvu": "^0.5.0"
-      }
-    },
-    "node_modules/micromark-util-symbol": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
-      "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "optional": true
-    },
-    "node_modules/micromark-util-types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
-      "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "optional": true
     },
     "node_modules/micromatch": {
       "version": "4.0.5",
@@ -17449,15 +16189,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/mri": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-      "optional": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/mrmime": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
@@ -17471,7 +16202,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/multicast-dns": {
       "version": "7.2.5",
@@ -17701,29 +16432,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/ngx-markdown": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/ngx-markdown/-/ngx-markdown-17.1.1.tgz",
-      "integrity": "sha512-BGNWGJ6tmfPx+ScZFq5qeGLgWJwsakjScZ2e+oUzm+97DAHpIHSl8gptNZvZgRhOiFdjLcKBcuY2Rz8WB6J6UQ==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "optionalDependencies": {
-        "clipboard": "^2.0.11",
-        "emoji-toolkit": "^8.0.0",
-        "katex": "^0.16.0",
-        "mermaid": "^10.6.0",
-        "prismjs": "^1.28.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "^17.0.0",
-        "@angular/core": "^17.0.0",
-        "@angular/platform-browser": "^17.0.0",
-        "marked": "^9.0.0",
-        "rxjs": "^6.5.3 || ^7.4.0",
-        "zone.js": "~0.14.0"
-      }
-    },
     "node_modules/nice-napi": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/nice-napi/-/nice-napi-1.0.2.tgz",
@@ -17872,12 +16580,6 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
       "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
       "dev": true
-    },
-    "node_modules/non-layered-tidy-tree-layout": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/non-layered-tidy-tree-layout/-/non-layered-tidy-tree-layout-2.0.2.tgz",
-      "integrity": "sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw==",
-      "optional": true
     },
     "node_modules/nopt": {
       "version": "7.2.0",
@@ -19328,15 +18030,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
-      "optional": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/proc-log": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-3.0.0.tgz",
@@ -20159,12 +18852,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/robust-predicates": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
-      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
-      "optional": true
-    },
     "node_modules/rollup": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.5.0.tgz",
@@ -20245,18 +18932,6 @@
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/sade": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
-      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
-      "optional": true,
-      "dependencies": {
-        "mri": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -20281,7 +18956,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/safevalues": {
       "version": "0.3.4",
@@ -20381,12 +19056,6 @@
       "dependencies": {
         "compute-scroll-into-view": "^3.0.2"
       }
-    },
-    "node_modules/select": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA==",
-      "optional": true
     },
     "node_modules/select-hose": {
       "version": "2.0.0",
@@ -21597,12 +20266,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/stylis": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.0.tgz",
-      "integrity": "sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ==",
-      "optional": true
-    },
     "node_modules/supercluster": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
@@ -21903,12 +20566,6 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
     },
-    "node_modules/tiny-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "optional": true
-    },
     "node_modules/tinyqueue": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
@@ -22020,15 +20677,6 @@
       },
       "peerDependencies": {
         "typescript": ">=4.2.0"
-      }
-    },
-    "node_modules/ts-dedent": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
-      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
-      "optional": true,
-      "engines": {
-        "node": ">=6.10"
       }
     },
     "node_modules/ts-node": {
@@ -22398,19 +21046,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/unist-util-stringify-position": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
-      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
-      "optional": true,
-      "dependencies": {
-        "@types/unist": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -22509,33 +21144,6 @@
       "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/uvu": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
-      "integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
-      "optional": true,
-      "dependencies": {
-        "dequal": "^2.0.0",
-        "diff": "^5.0.0",
-        "kleur": "^4.0.3",
-        "sade": "^1.7.3"
-      },
-      "bin": {
-        "uvu": "bin.js"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/uvu/node_modules/diff": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/v8-compile-cache": {
@@ -23116,12 +21724,6 @@
       "dependencies": {
         "defaults": "^1.0.3"
       }
-    },
-    "node_modules/web-worker": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
-      "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA==",
-      "optional": true
     },
     "node_modules/webpack": {
       "version": "5.89.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng run showcase:cypress-run",
-    "cypress:open": "ng run showcase:cypress-open"
+    "cypress:open": "ng run showcase:cypress-open",
+    "docs": "typedoc --entryPoints ./projects/ngx-maplibre-gl/src/public_api.ts --tsconfig ./projects/ngx-maplibre-gl/tsconfig.lib.json --out dist/showcase/API --treatWarningsAsErrors"
   },
   "private": true,
   "engines": {
@@ -78,6 +79,7 @@
     "pngjs": "^7.0.0",
     "standard-version": "^9.5.0",
     "ts-node": "^10.9.1",
+    "typedoc": "^0.25.12",
     "typescript": "^5.2.2"
   },
   "config": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "ng lint",
     "e2e": "ng run showcase:cypress-run",
     "cypress:open": "ng run showcase:cypress-open",
-    "docs": "typedoc --entryPoints ./projects/ngx-maplibre-gl/src/public_api.ts --tsconfig ./projects/ngx-maplibre-gl/tsconfig.lib.json --out dist/showcase/API --treatWarningsAsErrors"
+    "docs": "typedoc"
   },
   "private": true,
   "engines": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@stackblitz/sdk": "^1.9.0",
     "lodash-es": "^4.17.21",
     "maplibre-gl": "^4.0.0",
-    "ngx-markdown": "^17.1.1",
     "rxjs": "7.8.1",
     "scroll-into-view-if-needed": "^3.1.0",
     "tslib": "^2.6.2",

--- a/projects/ngx-maplibre-gl/src/lib/control/attribution-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/attribution-control.directive.ts
@@ -3,13 +3,19 @@ import { AttributionControl } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
 import { ControlComponent } from './control.component';
 
+/**
+ * `mglAttribution` - an attribution control directive
+ * 
+ * @category Directives
+ */
 @Directive({
   selector: '[mglAttribution]',
   standalone: true,
 })
 export class AttributionControlDirective implements AfterContentInit {
-  /* Init inputs */
+  /** Init input */
   @Input() compact?: boolean;
+  /** Init input */
   @Input() customAttribution?: string | string[];
 
   constructor(

--- a/projects/ngx-maplibre-gl/src/lib/control/attribution-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/attribution-control.directive.ts
@@ -7,6 +7,9 @@ import { ControlComponent } from './control.component';
  * `mglAttribution` - an attribution control directive
  * 
  * @category Directives
+ * 
+ * @see [Add custom attribution](https://maplibre.org/ngx-maplibre-gl/demo/custom-attribution)
+ * @see [AttributionControl](https://maplibre.org/maplibre-gl-js/docs/API/classes/AttributionControl)
  */
 @Directive({
   selector: '[mglAttribution]',

--- a/projects/ngx-maplibre-gl/src/lib/control/control.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/control.component.ts
@@ -26,6 +26,30 @@ export class CustomControl implements IControl {
   }
 }
 
+/**
+ * `mgl-control` - a custom control component
+ * @see [Controls](https://maplibre.org/maplibre-gl-js/docs/API/interfaces/IControl/)
+ * 
+ * @category Components
+ * 
+ * @example
+ * ```html
+ * ...
+ * <mgl-map ...>
+ *   <mgl-control> Hello </mgl-control>
+ *   ...
+ *   <mgl-control mglNavigation></mgl-control>
+ *   ...
+ *   <mgl-control mglScale unit="imperial" position="top-right"></mgl-control>
+ *   ...
+ *   <mgl-control
+ *     mglTerrain
+ *     source="rasterDemSource"
+ *     exaggeration="3.1"
+ *   ></mgl-control>
+ * </mgl-map>
+ * ```
+ */
 @Component({
   selector: 'mgl-control',
   template: '<div class="maplibregl-ctrl" #content><ng-content></ng-content></div>',
@@ -34,9 +58,9 @@ export class CustomControl implements IControl {
 })
 export class ControlComponent<T extends IControl>
   implements OnDestroy, AfterContentInit {
-  /* Init inputs */
+  /** Init input */
   @Input() position?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
-
+  /** @hidden */
   @ViewChild('content', { static: true }) content: ElementRef;
 
   control: T | CustomControl;

--- a/projects/ngx-maplibre-gl/src/lib/control/fullscreen-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/fullscreen-control.directive.ts
@@ -9,6 +9,11 @@ import { FullscreenControl } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
 import { ControlComponent } from './control.component';
 
+/**
+ * `mglFullscreen` - a fullscreen control directive
+ * 
+ * @category Directives
+ */
 @Directive({
   selector: '[mglFullscreen]',
   standalone: true,

--- a/projects/ngx-maplibre-gl/src/lib/control/geolocate-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/geolocate-control.directive.ts
@@ -11,6 +11,11 @@ import { MapService } from '../map/map.service';
 import { ControlComponent } from './control.component';
 import { Position } from '../map/map.types';
 
+/**
+ * `mglGeolocate` - a geolocate control directive
+ * 
+ * @category Directives
+ */
 @Directive({
   selector: '[mglGeolocate]',
   standalone: true,

--- a/projects/ngx-maplibre-gl/src/lib/control/geolocate-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/geolocate-control.directive.ts
@@ -15,6 +15,9 @@ import { Position } from '../map/map.types';
  * `mglGeolocate` - a geolocate control directive
  * 
  * @category Directives
+ * 
+ * @see [Locate user](https://maplibre.org/ngx-maplibre-gl/demo/locate-user)
+ * @see [GeolocateControl](https://maplibre.org/maplibre-gl-js/docs/API/classes/GeolocateControl)
  */
 @Directive({
   selector: '[mglGeolocate]',

--- a/projects/ngx-maplibre-gl/src/lib/control/navigation-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/navigation-control.directive.ts
@@ -3,6 +3,11 @@ import { NavigationControl } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
 import { ControlComponent } from './control.component';
 
+/**
+ * `mglNavigation` - a navigation control directive
+ * 
+ * @category Directives
+ */
 @Directive({
   selector: '[mglNavigation]',
   standalone: true,

--- a/projects/ngx-maplibre-gl/src/lib/control/navigation-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/navigation-control.directive.ts
@@ -7,6 +7,9 @@ import { ControlComponent } from './control.component';
  * `mglNavigation` - a navigation control directive
  * 
  * @category Directives
+ * 
+ * @see [Navigation](https://maplibre.org/ngx-maplibre-gl/demo/navigation)
+ * @see [NavigationControl](https://maplibre.org/maplibre-gl-js/docs/API/classes/NavigationControl)
  */
 @Directive({
   selector: '[mglNavigation]',

--- a/projects/ngx-maplibre-gl/src/lib/control/scale-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/scale-control.directive.ts
@@ -14,6 +14,9 @@ import { ControlComponent } from './control.component';
  * `mglScale` - a scale control directive
  * 
  * @category Directives
+ * 
+ * @see [Scale](https://maplibre.org/ngx-maplibre-gl/demo/ngx-scale-control)
+ * @see [ScaleControl](https://maplibre.org/maplibre-gl-js/docs/API/classes/ScaleControl)
  */
 @Directive({
   selector: '[mglScale]',

--- a/projects/ngx-maplibre-gl/src/lib/control/scale-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/scale-control.directive.ts
@@ -10,6 +10,11 @@ import { ScaleControl, ScaleControlOptions } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
 import { ControlComponent } from './control.component';
 
+/**
+ * `mglScale` - a scale control directive
+ * 
+ * @category Directives
+ */
 @Directive({
   selector: '[mglScale]',
   standalone: true,

--- a/projects/ngx-maplibre-gl/src/lib/control/terrain-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/terrain-control.directive.ts
@@ -7,6 +7,9 @@ import { ControlComponent } from './control.component';
  * `mglTerrain` - a terrain control directive
  * 
  * @category Directives
+ * 
+ * @see [Terrain](https://maplibre.org/ngx-maplibre-gl/demo/terrain-control)
+ * @see [TerrainControl](https://maplibre.org/maplibre-gl-js/docs/API/classes/TerrainControl)
  */
 @Directive({
   selector: '[mglTerrain]',

--- a/projects/ngx-maplibre-gl/src/lib/control/terrain-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/terrain-control.directive.ts
@@ -3,6 +3,11 @@ import { TerrainControl, TerrainSpecification } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
 import { ControlComponent } from './control.component';
 
+/**
+ * `mglTerrain` - a terrain control directive
+ * 
+ * @category Directives
+ */
 @Directive({
   selector: '[mglTerrain]',
   standalone: true,

--- a/projects/ngx-maplibre-gl/src/lib/draggable/draggable.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/draggable/draggable.directive.ts
@@ -16,6 +16,11 @@ import { LayerComponent } from '../layer/layer.component';
 import { MapService } from '../map/map.service';
 import { FeatureComponent } from '../source/geojson/feature.component';
 
+/**
+ * `mglDraggable` - a directive for Feature or Marker
+ * 
+ * @category Directives
+ */
 @Directive({
   selector: '[mglDraggable]',
   standalone: true,

--- a/projects/ngx-maplibre-gl/src/lib/draggable/draggable.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/draggable/draggable.directive.ts
@@ -20,6 +20,8 @@ import { FeatureComponent } from '../source/geojson/feature.component';
  * `mglDraggable` - a directive for Feature or Marker
  * 
  * @category Directives
+ * 
+ * @see [Draggable Marker](https://maplibre.org/ng-maplibre-gl/demo/ngx-drag-a-point)
  */
 @Directive({
   selector: '[mglDraggable]',

--- a/projects/ngx-maplibre-gl/src/lib/image/image.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/image/image.component.ts
@@ -14,18 +14,51 @@ import { filter, startWith, switchMap } from 'rxjs/operators';
 import { MapService } from '../map/map.service';
 import { MapImageData, MapImageOptions } from '../map/map.types';
 
+/**
+ * `mgl-image` - an image component
+ * @see [addImage](https://maplibre.org/maplibre-gl-js/docs/API/classes/Map/#addimage)
+ * 
+ * @category Components
+ * 
+ * @example
+ * ```html
+ * ...
+ * <mgl-map
+ *   ...
+ * >
+ *    <mgl-image
+ *      id="image"
+ *      url="https://..."
+ *      (imageLoaded)="imageLoaded = true"
+ *    >
+ *    ...
+ *    <mgl-image
+ *      id="image2"
+ *      [data]="{
+ *        width: 64,
+ *        height: 64,
+ *        data: imageData
+ *      }"
+ *    >
+ * </mgl-map>
+ * ...
+ * imageData: Uint8Array;
+ * ```
+ */
 @Component({
   selector: 'mgl-image',
   template: '',
   standalone: true,
 })
 export class ImageComponent implements OnInit, OnDestroy, OnChanges {
-  /* Init inputs */
+  /** Init input */
   @Input() id: string;
 
-  /* Dynamic inputs */
+  /** Dynamic input */
   @Input() data?: MapImageData;
+  /** Dynamic input */
   @Input() options?: MapImageOptions;
+  /** Dynamic input */
   @Input() url?: string;
 
   @Output() imageError = new EventEmitter<{ status: number }>();

--- a/projects/ngx-maplibre-gl/src/lib/layer/layer.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/layer/layer.component.ts
@@ -19,6 +19,28 @@ import { filter, map, startWith, switchMap } from 'rxjs/operators';
 import { MapService, SetupLayer } from '../map/map.service';
 import { EventData, LayerEvents } from '../map/map.types';
 
+/**
+ * `mgl-layer` - a layer component
+ * @see [layers](https://maplibre.org/maplibre-style-spec/layers/)
+ * 
+ * @category Layer Component
+ * 
+ * @example
+ * ```html
+ * ...
+ * <mgl-map ...>
+ *   <mgl-layer
+ *     id="state-borders"
+ *     type="line"
+ *     [source]="states"
+ *     [paint]="{
+ *       'line-color': '#627BC1',
+ *       'line-width': 2
+ *     }"
+ *   ></mgl-layer>
+ * </mgl-map>
+ * ```
+ */
 @Component({
   selector: 'mgl-layer',
   template: '',
@@ -26,23 +48,34 @@ import { EventData, LayerEvents } from '../map/map.types';
 })
 export class LayerComponent
   implements OnInit, OnDestroy, OnChanges, LayerEvents {
-  /* Init inputs */
+  /** Init input */
   @Input() id: LayerSpecification['id'];
+  /** Init input */
   @Input() source?: string;
+  /** Init input */
   @Input() type: LayerSpecification['type'];
+  /** Init input */
   @Input() metadata?: LayerSpecification['metadata'];
+  /** Init input */
   @Input() sourceLayer?: string;
   /**
    * A flag to enable removeSource clean up functionality
+   * 
+   * Init input
    */
   @Input() removeSource?: boolean;
 
-  /* Dynamic inputs */
+  /** Dynamic input */
   @Input() filter?: FilterSpecification;
+  /** Dynamic input */
   @Input() layout?: LayerSpecification['layout'];
+  /** Dynamic input */
   @Input() paint?: LayerSpecification['paint'];
+  /** Dynamic input */
   @Input() before?: string;
+  /** Dynamic input */
   @Input() minzoom?: LayerSpecification['minzoom'];
+  /** Dynamic input */
   @Input() maxzoom?: LayerSpecification['maxzoom'];
 
   @Output() layerClick = new EventEmitter<MapLayerMouseEvent & EventData>();

--- a/projects/ngx-maplibre-gl/src/lib/map/map.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/map/map.component.ts
@@ -32,6 +32,33 @@ import { MapService, MovingOptions } from './map.service';
 import { MapEvent, EventData } from './map.types';
 import { Subscription, firstValueFrom } from 'rxjs';
 
+/**
+ * `mgl-map` - The main map component
+ * @see [Map](https://maplibre.org/maplibre-gl-js/docs/API/classes/Map/)
+ * 
+ * @category Map Component
+ * 
+ * @example
+ * ```typescript
+ * ...
+ * @Component({
+ *   template: `
+ *   <mgl-map
+ *     [style]="'https://demotiles.maplibre.org/style.json'"
+ *     [zoom]="[9]"
+ *     [center]="[-74.50, 40]"
+ *     (mapLoad)="map = $event"
+ *   ></mgl-map>
+ *   `,
+ * ...
+ * })
+ * export class DisplayMapComponent {
+ *   map: Map; // MapLibre GL Map object (MapLibre is ran outside angular zone, keep that in mind when binding events from this object)
+ * ...
+ * }
+ * ```
+ */
+
 @Component({
   selector: 'mgl-map',
   template: '<div #container></div>',
@@ -57,57 +84,100 @@ export class MapComponent
     AfterViewInit,
     Omit<MapOptions, 'bearing' | 'container' | 'pitch' | 'zoom'>,
     MapEvent {
-  /* Init inputs */
+  /** Init input */
   @Input() collectResourceTiming?: MapOptions['collectResourceTiming'];
+  /** Init input */
   @Input() crossSourceCollisions?: MapOptions['crossSourceCollisions'];
+  /** Init input */
   @Input() customMapboxApiUrl?: string;
+  /** Init input */
   @Input() fadeDuration?: MapOptions['fadeDuration'];
+  /** Init input */
   @Input() hash?: MapOptions['hash'];
+  /** Init input */
   @Input() refreshExpiredTiles?: MapOptions['refreshExpiredTiles'];
+  /** Init input */
   @Input()
   failIfMajorPerformanceCaveat?: MapOptions['failIfMajorPerformanceCaveat'];
+  /** Init input */
   @Input() bearingSnap?: MapOptions['bearingSnap'];
+  /** Init input */
   @Input() interactive?: MapOptions['interactive'];
+  /** Init input */
   @Input() pitchWithRotate?: MapOptions['pitchWithRotate'];
+  /** Init input */
   @Input() clickTolerance?: MapOptions['clickTolerance'];
+  /** Init input */
   @Input() attributionControl?: MapOptions['attributionControl'];
+  /** Init input */
   @Input() logoPosition?: MapOptions['logoPosition'];
+  /** Init input */
   @Input() maxTileCacheSize?: MapOptions['maxTileCacheSize'];
+  /** Init input */
   @Input() localIdeographFontFamily?: MapOptions['localIdeographFontFamily'];
+  /** Init input */
   @Input() preserveDrawingBuffer?: MapOptions['preserveDrawingBuffer'];
+  /** Init input */
   @Input() trackResize?: MapOptions['trackResize'];
+  /** Init input */
   @Input() transformRequest?: MapOptions['transformRequest'];
+  /** Init input */
   @Input() bounds?: MapOptions['bounds']; // Use fitBounds for dynamic input
+  /** Init input */
   @Input() antialias?: MapOptions['antialias'];
+  /** Init input */
   @Input() locale: MapOptions['locale'];
+  /** Init inputs */
   @Input() cooperativeGestures?: MapOptions['cooperativeGestures'];
 
-  /* Dynamic inputs */
+  /** Dynamic input */
   @Input() minZoom?: MapOptions['minZoom'];
+  /** Dynamic input */
   @Input() maxZoom?: MapOptions['maxZoom'];
+  /** Dynamic input */
   @Input() minPitch?: MapOptions['minPitch'];
+  /** Dynamic input */
   @Input() maxPitch?: MapOptions['maxPitch'];
+  /** Dynamic input */
   @Input() scrollZoom?: MapOptions['scrollZoom'];
+  /** Dynamic input */
   @Input() dragRotate?: MapOptions['dragRotate'];
+  /** Dynamic input */
   @Input() touchPitch?: MapOptions['touchPitch'];
+  /** Dynamic input */
   @Input() touchZoomRotate?: MapOptions['touchZoomRotate'];
+  /** Dynamic input */
   @Input() doubleClickZoom?: MapOptions['doubleClickZoom'];
+  /** Dynamic input */
   @Input() keyboard?: MapOptions['keyboard'];
+  /** Dynamic input */
   @Input() dragPan?: MapOptions['dragPan'];
+  /** Dynamic input */
   @Input() boxZoom?: MapOptions['boxZoom'];
+  /** Dynamic input */
   @Input() style: MapOptions['style'];
+  /** Dynamic input */
   @Input() center?: MapOptions['center'];
+  /** Dynamic input */
   @Input() maxBounds?: MapOptions['maxBounds'];
+  /** Dynamic input */
   @Input() zoom?: [number];
+  /** Dynamic input */
   @Input() bearing?: [number];
+  /** Dynamic input */
   @Input() pitch?: [number];
+  /** Dynamic input */
   @Input() fitBoundsOptions?: MapOptions['fitBoundsOptions']; // First value goes to options.fitBoundsOptions. Subsequents changes are passed to fitBounds
+  /** Dynamic input */
   @Input() renderWorldCopies?: MapOptions['renderWorldCopies'];
-
-  /* Added by ngx-mapbox-gl */
-  @Input() movingMethod: 'jumpTo' | 'easeTo' | 'flyTo' = 'flyTo';
-  @Input() movingOptions?: MovingOptions;
+  /** Dynamic input */
   @Input() terrain: TerrainSpecification;
+
+  /** Added by ngx-mapbox-gl */
+  @Input() movingMethod: 'jumpTo' | 'easeTo' | 'flyTo' = 'flyTo';
+  /** Added by ngx-mapbox-gl */
+  @Input() movingOptions?: MovingOptions;
+  
 
   // => First value is a alias to bounds input (since mapbox 0.53.0). Subsequents changes are passed to fitBounds
   @Input() fitBounds?: LngLatBoundsLike;

--- a/projects/ngx-maplibre-gl/src/lib/marker/marker.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/marker/marker.component.ts
@@ -16,6 +16,24 @@ import {
 import { LngLatLike, Marker, MarkerOptions } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
 
+/**
+ * `mgl-marker` - a marker component
+ * @see [Marker](https://maplibre.org/maplibre-gl-js/docs/API/classes/Marker/)
+ * 
+ * @category Components
+ * 
+ * @example
+ * ```html
+ * ...
+ * <mgl-map ...>
+ *   <mgl-marker [lngLat]="[-66.324462890625, -16.024695711685304]">
+ *     <div (click)="alert('Foo')" class="marker">Hello</div>
+ *   </mgl-marker>
+ * </mgl-map>
+ * ```
+ * 
+ * Note: Only use this if you **really** need to use HTML/Angular component to render your symbol. These markers are slow compared to a `Layer` of symbol because they're not rendered using WebGL.
+ */
 @Component({
   selector: 'mgl-marker',
   template: '<div [class]="className" #content><ng-content></ng-content></div>',

--- a/projects/ngx-maplibre-gl/src/lib/markers-for-clusters/markers-for-clusters.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/markers-for-clusters/markers-for-clusters.component.ts
@@ -18,12 +18,22 @@ import { MarkerComponent } from '../marker/marker.component';
 import { NgFor, NgIf, NgTemplateOutlet } from '@angular/common';
 import { LayerComponent } from '../layer/layer.component';
 
+/**
+ * a template directive for point for {@link MarkersForClustersComponent}
+ * 
+ * @category Directives
+ */
 @Directive({
   selector: 'ng-template[mglPoint]',
   standalone: true,
 })
 export class PointDirective {}
 
+/**
+ * a template directive for clustered point for {@link MarkersForClustersComponent}
+ * 
+ * @category Directives
+ */
 @Directive({
   selector: 'ng-template[mglClusterPoint]',
   standalone: true,
@@ -32,7 +42,29 @@ export class ClusterPointDirective {}
 
 let uniqId = 0;
 
-@Component({
+/**
+ * [ngx] `mgl-markers-for-clusters` - an HTML marker component for clustered points.
+ * Requires a geojson source that is clustered.
+ * 
+ * @category Components
+ * 
+ * @example
+ * ```html
+ * ...
+ * <mgl-map ...>
+ *   <mgl-markers-for-cluster [source]="myGeoJsonclusteredSource">
+ *     <ng-template mglPoint let-feature> Marker! </ng-template>
+ *     <ng-template mglClusterPoint let-feature>
+ *       ClusterId: {{feature.properties?.cluster_id}}, Points:
+ *       {{feature.properties?.point_count}}
+ *     </ng-template>
+ *   </mgl-markers-for-cluster>
+ * </mgl-map>
+ * ```
+ * 
+ * Note: Only use this if you **really** need to use HTML/Angular component to render your symbols. This is **slower** than rendering symbols in WebGL.
+ */ 
+ @Component({
   selector: 'mgl-markers-for-clusters',
   template: `
     <mgl-layer
@@ -67,15 +99,19 @@ let uniqId = 0;
 })
 export class MarkersForClustersComponent
   implements OnDestroy, AfterContentInit {
-  /* Init input */
+  /** Init input */
   @Input() source: string;
 
+  /** @hidden */
   @ContentChild(PointDirective, { read: TemplateRef, static: false })
   pointTpl?: TemplateRef<any>;
+  /** @hidden */
   @ContentChild(ClusterPointDirective, { read: TemplateRef, static: false })
   clusterPointTpl: TemplateRef<any>;
 
+  /** @hidden */
   clusterPoints: MapGeoJSONFeature[];
+  /** @hidden */
   layerId = `mgl-markers-for-clusters-${uniqId++}`;
 
   private sub = new Subscription();

--- a/projects/ngx-maplibre-gl/src/lib/popup/popup.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/popup/popup.component.ts
@@ -16,6 +16,25 @@ import { LngLatLike, Offset, Popup, PopupOptions } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
 import { MarkerComponent } from '../marker/marker.component';
 
+/**
+ * `mgl-popup` - a popup component
+ * @see [Popup](https://maplibre.org/maplibre-gl-js/docs/API/classes/Popup/)
+ * 
+ * @category Components
+ * 
+ * @example
+ * ```html
+ * ...
+ * <mgl-map ...>
+ *   <mgl-popup [lngLat]="[-96, 37.8]" [closeOnClick]="false">
+ *     <h1>Hello world !</h1>
+ *   </mgl-popup>
+ *   ...
+ *   <mgl-marker #myMarker ...> ... </mgl-marker>
+ *   <mgl-popup [marker]="myMarker"> Hello from marker ! </mgl-popup>
+ * </mgl-map>
+ * ```
+ */
 @Component({
   selector: 'mgl-popup',
   template: '<div #content data-cy="mgl-popup"><ng-content></ng-content></div>',
@@ -25,24 +44,40 @@ import { MarkerComponent } from '../marker/marker.component';
 export class PopupComponent
   implements OnChanges, OnDestroy, AfterViewInit, OnInit
 {
-  /* Init input */
+  /** Init input */
   @Input() closeButton?: PopupOptions['closeButton'];
+  /** Init input */
   @Input() closeOnClick?: PopupOptions['closeOnClick'];
+  /** Init input */
   @Input() closeOnMove?: PopupOptions['closeOnMove'];
+  /** Init input */
   @Input() focusAfterOpen?: PopupOptions['focusAfterOpen'];
+  /** Init input */
   @Input() anchor?: PopupOptions['anchor'];
+  /** Init input */
   @Input() className?: PopupOptions['className'];
+  /** Init input */
   @Input() maxWidth?: PopupOptions['maxWidth'];
 
-  /* Dynamic input */
+  /** 
+   * Dynamic input [ngx]
+   * Mutually exclusive with `lngLat`
+   */
   @Input() feature?: GeoJSON.Feature<GeoJSON.Point>;
+  /** Dynamic input */
   @Input() lngLat?: LngLatLike;
+  /** 
+   * Dynamic input [ngx]
+   * The targeted marker
+   */
   @Input() marker?: MarkerComponent;
+  /** Dynamic input */
   @Input() offset?: Offset;
 
   @Output() popupClose = new EventEmitter<void>();
   @Output() popupOpen = new EventEmitter<void>();
 
+  /** @hidden */
   @ViewChild('content', { static: true }) content: ElementRef;
 
   popupInstance?: maplibregl.Popup;

--- a/projects/ngx-maplibre-gl/src/lib/source/canvas-source.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/canvas-source.component.ts
@@ -7,23 +7,17 @@ import {
   OnInit,
   SimpleChanges,
 } from '@angular/core';
-import { CanvasSource } from 'maplibre-gl';
+import { CanvasSource, CanvasSourceSpecification } from 'maplibre-gl';
 import { fromEvent, Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import { MapService } from '../map/map.service';
 
-interface CanvasSourceSpecification {
-  type: 'canvas';
-  coordinates: [
-    [number, number],
-    [number, number],
-    [number, number],
-    [number, number]
-  ];
-  animate?: boolean;
-  canvas: string | HTMLCanvasElement;
-}
-
+/**
+ * `mgl-canvas-source` - a canvas source component
+ * @see [canvas](https://maplibre.org/maplibre-style-spec/sources/#canvas)
+ * 
+ * @category Source Components
+ */
 @Component({
   selector: 'mgl-canvas-source',
   template: '',
@@ -32,12 +26,14 @@ interface CanvasSourceSpecification {
 })
 export class CanvasSourceComponent
   implements OnInit, OnDestroy, OnChanges, CanvasSourceSpecification {
-  /* Init inputs */
+  /**  Init input */
   @Input() id: string;
 
-  /* Dynamic inputs */
+  /** Dynamic input */
   @Input() coordinates: CanvasSourceSpecification['coordinates'];
+  /** Dynamic input */
   @Input() canvas: CanvasSourceSpecification['canvas'];
+  /** Dynamic input */
   @Input() animate?: CanvasSourceSpecification['animate'];
 
   type: CanvasSourceSpecification['type'] = 'canvas';

--- a/projects/ngx-maplibre-gl/src/lib/source/geojson/feature.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/geojson/feature.component.ts
@@ -9,6 +9,12 @@ import {
 } from '@angular/core';
 import { GeoJSONSourceComponent } from './geojson-source.component';
 
+/**
+ * `mgl-feature` - a feature component
+ * [ngx] inside {@link GeoJSONSourceComponent} only
+ * 
+ * @category Source Components
+ */
 @Component({
     selector: 'mgl-feature',
     template: '',
@@ -17,9 +23,11 @@ import { GeoJSONSourceComponent } from './geojson-source.component';
 })
 export class FeatureComponent
   implements OnInit, OnDestroy, GeoJSON.Feature<GeoJSON.GeometryObject> {
-  /* Init inputs */
+  /** Init input */
   @Input() id?: number; // FIXME number only for now https://github.com/mapbox/mapbox-gl-js/issues/2716
+  /** Init input */
   @Input() geometry: GeoJSON.GeometryObject;
+  /** Init input */
   @Input() properties: any;
   type: 'Feature' = 'Feature';
 

--- a/projects/ngx-maplibre-gl/src/lib/source/geojson/geojson-source.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/geojson/geojson-source.component.ts
@@ -13,6 +13,34 @@ import { fromEvent, Subject, Subscription } from 'rxjs';
 import { debounceTime, filter } from 'rxjs/operators';
 import { MapService } from '../../map/map.service';
 
+/**
+ * `mgl-geojson-source` - a geojson source component 
+ * @see [geojson](https://maplibre.org/maplibre-gl-js/docs/API/classes/maplibregl.GeoJSONSource/)
+ * 
+ * @category Source Components
+ * 
+ * @example
+ * ```html
+ * ...
+ * <mgl-map ...>
+ *   <mgl-geojson-source id="symbols-source">
+ *     <mgl-feature
+ *       *ngFor="let geometry of geometries"
+ *       [geometry]="geometry"
+ *     ></mgl-feature>
+ *   </mgl-geojson-source>
+ *   ...
+ *   <mgl-geojson-source
+ *     id="earthquakes"
+ *     [data]="earthquakes"
+ *     [cluster]="true"
+ *     [clusterMaxZoom]="14"
+ *     [clusterRadius]="50"
+ *   ></mgl-geojson-source>
+ * </mgl-map>
+ * 
+ * ```
+ */
 @Component({
     selector: 'mgl-geojson-source',
     template: '',
@@ -21,25 +49,39 @@ import { MapService } from '../../map/map.service';
 })
 export class GeoJSONSourceComponent
   implements OnInit, OnDestroy, OnChanges, GeoJSONSourceSpecification {
-  /* Init inputs */
+  /** Init input */
   @Input() id: string;
 
-  /* Dynamic inputs */
+  /** Dynamic input */
   @Input() data: GeoJSONSourceSpecification['data'];
+  /** Dynamic input */
   @Input() maxzoom?: GeoJSONSourceSpecification['maxzoom'];
+  /** Dynamic input */
   @Input() attribution?: GeoJSONSourceSpecification['attribution'];
+  /** Dynamic input */
   @Input() buffer?: GeoJSONSourceSpecification['buffer'];
+  /** Dynamic input */
   @Input() tolerance?: GeoJSONSourceSpecification['tolerance'];
+  /** Dynamic input */
   @Input() cluster?: GeoJSONSourceSpecification['cluster'];
+  /** Dynamic input */
   @Input() clusterRadius?: GeoJSONSourceSpecification['clusterRadius'];
+  /** Dynamic input */
   @Input() clusterMaxZoom?: GeoJSONSourceSpecification['clusterMaxZoom'];
+  /** Dynamic input */
   @Input() clusterMinPoints?: GeoJSONSourceSpecification['clusterMinPoints'];
+  /** Dynamic input */
   @Input() clusterProperties?: GeoJSONSourceSpecification['clusterProperties'];
+  /** Dynamic input */
   @Input() lineMetrics?: GeoJSONSourceSpecification['lineMetrics'];
+  /** Dynamic input */
   @Input() generateId?: GeoJSONSourceSpecification['generateId'];
+  /** Dynamic input */
   @Input() promoteId?: GeoJSONSourceSpecification['promoteId'];
+  /** Dynamic input */
   @Input() filter?: GeoJSONSourceSpecification['filter'];
 
+  /** @hidden */
   type: GeoJSONSourceSpecification['type'] = 'geojson';
 
   updateFeatureData = new Subject();

--- a/projects/ngx-maplibre-gl/src/lib/source/raster-dem-source.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/raster-dem-source.component.ts
@@ -12,6 +12,12 @@ import { fromEvent, Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import { MapService } from '../map/map.service';
 
+/**
+ * `mgl-raster-dem-source` - a raster DEM source
+ * @see [raster DEM](https://maplibre.org/maplibre-style-spec/sources/#raster-dem)
+ * 
+ * @category Source Components
+ */
 @Component({
   selector: 'mgl-raster-dem-source',
   template: '',
@@ -20,19 +26,27 @@ import { MapService } from '../map/map.service';
 })
 export class RasterDemSourceComponent
   implements OnInit, OnDestroy, OnChanges, RasterDEMSourceSpecification {
-  /* Init inputs */
+  /** Init input */
   @Input() id: string;
 
-  /* Dynamic inputs */
+  /** Dynamic input */
   @Input() url?: RasterDEMSourceSpecification['url'];
+  /** Dynamic input */
   @Input() tiles?: RasterDEMSourceSpecification['tiles'];
+  /** Dynamic input */
   @Input() bounds?: RasterDEMSourceSpecification['bounds'];
+  /** Dynamic input */
   @Input() minzoom?: RasterDEMSourceSpecification['minzoom'];
+  /** Dynamic input */
   @Input() maxzoom?: RasterDEMSourceSpecification['maxzoom'];
+  /** Dynamic input */
   @Input() tileSize?: RasterDEMSourceSpecification['tileSize'];
+  /** Dynamic input */
   @Input() attribution?: RasterDEMSourceSpecification['attribution'];
+  /** Dynamic input */
   @Input() encoding?: RasterDEMSourceSpecification['encoding'];
 
+  /** @hidden */
   type: RasterDEMSourceSpecification['type'] = 'raster-dem';
 
   private sourceAdded = false;

--- a/projects/ngx-maplibre-gl/src/lib/source/raster-source.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/raster-source.component.ts
@@ -12,6 +12,12 @@ import { fromEvent, Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import { MapService } from '../map/map.service';
 
+/**
+ * `mgl-raster-source` - a raster source component
+ * @see [raster](https://maplibre.org/maplibre-style-spec/sources/#raster)
+ * 
+ * @category Source Components
+ */
 @Component({
   selector: 'mgl-raster-source',
   template: '',
@@ -20,19 +26,27 @@ import { MapService } from '../map/map.service';
 })
 export class RasterSourceComponent
   implements OnInit, OnDestroy, OnChanges, RasterSourceSpecification {
-  /* Init inputs */
+  /** Init input */
   @Input() id: string;
 
-  /* Dynamic inputs */
+  /** Dynamic input */
   @Input() url?: RasterSourceSpecification['url'];
+  /** Dynamic input */
   @Input() tiles?: RasterSourceSpecification['tiles'];
+  /** Dynamic input */
   @Input() bounds?: RasterSourceSpecification['bounds'];
+  /** Dynamic input */
   @Input() minzoom?: RasterSourceSpecification['minzoom'];
+  /** Dynamic input */
   @Input() maxzoom?: RasterSourceSpecification['maxzoom'];
+  /** Dynamic input */
   @Input() tileSize?: RasterSourceSpecification['tileSize'];
+  /** Dynamic input */
   @Input() scheme?: RasterSourceSpecification['scheme'];
+  /** Dynamic input */
   @Input() attribution?: RasterSourceSpecification['attribution'];
 
+  /** @hidden */
   type: RasterSourceSpecification['type'] = 'raster';
 
   private sourceAdded = false;

--- a/projects/ngx-maplibre-gl/src/lib/source/vector-source.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/vector-source.component.ts
@@ -12,6 +12,12 @@ import { fromEvent, Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import { MapService } from '../map/map.service';
 
+/**
+ * `mgl-vector-source` - a vector source component
+ * @see [vector](https://maplibre.org/maplibre-style-spec/sources/#vector)
+ * 
+ * @category Source Components
+ */
 @Component({
   selector: 'mgl-vector-source',
   template: '',

--- a/projects/ngx-maplibre-gl/src/lib/source/video-source.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/video-source.component.ts
@@ -12,6 +12,12 @@ import { fromEvent, Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import { MapService } from '../map/map.service';
 
+/**
+ * `mgl-video-source` - a video source 
+ * @see [video](https://maplibre.org/maplibre-style-spec/sources/#video)
+ * 
+ * @category Source Components
+ */
 @Component({
   selector: 'mgl-video-source',
   template: '',
@@ -20,13 +26,15 @@ import { MapService } from '../map/map.service';
 })
 export class VideoSourceComponent
   implements OnInit, OnDestroy, OnChanges, VideoSourceSpecification {
-  /* Init inputs */
+  /** Init input */
   @Input() id: string;
 
-  /* Dynamic inputs */
+  /** Dynamic input */
   @Input() urls: VideoSourceSpecification['urls'];
+  /** Dynamic input */
   @Input() coordinates: VideoSourceSpecification['coordinates'];
 
+  /** @hidden */
   type: VideoSourceSpecification['type'] = 'video';
 
   private sourceAdded = false;

--- a/projects/showcase/src/app/app.config.ts
+++ b/projects/showcase/src/app/app.config.ts
@@ -3,14 +3,12 @@ import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
 import { provideHttpClient } from '@angular/common/http';
-import { provideMarkdown } from 'ngx-markdown';
 import { provideAnimations } from '@angular/platform-browser/animations';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideRouter(routes),
     provideHttpClient(),
-    provideMarkdown(),
     provideAnimations(),
   ],
 };

--- a/projects/showcase/src/app/doc/doc.component.ts
+++ b/projects/showcase/src/app/doc/doc.component.ts
@@ -10,7 +10,7 @@ import 'prismjs/components/prism-typescript.min.js';
 
 @Component({
   template: `
-    <iframe src="https://www.maplibre.org/ngx-maplibre-gl/API"></iframe>
+    <iframe src="https://www.maplibre.org/ngx-maplibre-gl/API/modules.html"></iframe>
   `,
   styles: [
     `

--- a/projects/showcase/src/app/doc/doc.component.ts
+++ b/projects/showcase/src/app/doc/doc.component.ts
@@ -5,7 +5,6 @@ import { FormsModule } from '@angular/forms';
 import { MatSelectModule } from '@angular/material/select';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { LayoutToolbarMenuComponent } from '../shared/layout/layout-toolbar-menu.component';
-import 'prismjs/components/prism-typescript.min.js';
 
 @Component({
   template: `

--- a/projects/showcase/src/app/doc/doc.component.ts
+++ b/projects/showcase/src/app/doc/doc.component.ts
@@ -1,5 +1,4 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { MarkdownComponent } from 'ngx-markdown';
 import { MatOptionModule } from '@angular/material/core';
 import { NgFor } from '@angular/common';
 import { FormsModule } from '@angular/forms';
@@ -41,7 +40,6 @@ import 'prismjs/components/prism-typescript.min.js';
     FormsModule,
     NgFor,
     MatOptionModule,
-    MarkdownComponent,
   ],
 })
 export class DocComponent {

--- a/projects/showcase/src/app/doc/doc.component.ts
+++ b/projects/showcase/src/app/doc/doc.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { MarkdownComponent } from 'ngx-markdown';
 import { MatOptionModule } from '@angular/material/core';
 import { NgFor } from '@angular/common';
@@ -8,23 +8,9 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { LayoutToolbarMenuComponent } from '../shared/layout/layout-toolbar-menu.component';
 import 'prismjs/components/prism-typescript.min.js';
 
-export const VERSIONS = ['main'];
-
 @Component({
   template: `
-    <showcase-layout-toolbar-menu position="right">
-      <mat-form-field>
-        <mat-select
-          [(ngModel)]="currentVersion"
-          (ngModelChange)="updateDocUrl()"
-        >
-          <mat-option *ngFor="let version of VERSIONS" [value]="version">
-            {{ version }}
-          </mat-option>
-        </mat-select>
-      </mat-form-field>
-    </showcase-layout-toolbar-menu>
-    <markdown [src]="docUrl"></markdown>
+    <iframe src="https://www.maplibre.org/ngx-maplibre-gl/API"></iframe>
   `,
   styles: [
     `
@@ -35,13 +21,14 @@ export const VERSIONS = ['main'];
         justify-content: center;
       }
 
-      mat-form-field {
-        width: 100px;
-      }
-
-      markdown {
-        margin: 8px;
+      iframe {
         width: 60%;
+        border: none;
+      }
+      @media (max-width: 640px) {
+        iframe {
+          width: 100%;
+        }
       }
     `,
   ],
@@ -57,16 +44,5 @@ export const VERSIONS = ['main'];
     MarkdownComponent,
   ],
 })
-export class DocComponent implements OnInit {
-  VERSIONS = VERSIONS;
-  currentVersion = 'main';
-  docUrl: string;
-
-  ngOnInit() {
-    this.updateDocUrl();
-  }
-
-  updateDocUrl() {
-    this.docUrl = `https://raw.githubusercontent.com/maplibre/ngx-maplibre-gl/${this.currentVersion}/docs/API.md`;
-  }
+export class DocComponent {
 }

--- a/projects/showcase/src/styles.css
+++ b/projects/showcase/src/styles.css
@@ -1,6 +1,5 @@
 @import '@angular/material/prebuilt-themes/indigo-pink.css';
 @import '~maplibre-gl/dist/maplibre-gl.css';
-@import '~prismjs/themes/prism-okaidia.css';
 
 body {
   margin: 0;

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,9 @@
+{
+    "navigation": {
+        "includeCategories": true
+    },
+    "entryPoints": ["./projects/ngx-maplibre-gl/src/public_api.ts"],
+    "tsconfig": "./projects/ngx-maplibre-gl/tsconfig.lib.json",
+    "out": "dist/showcase/API",
+    "treatWarningsAsErrors": true
+}


### PR DESCRIPTION
Fixes #150 

This basically moves all the docs to the code itself in order to be able to generate a static site from it.
Currently it looks like the following:
![image](https://github.com/maplibre/ngx-maplibre-gl/assets/3269297/87b7c687-2844-437e-b691-2ef52b0dfb96)

I still need to understand how to properly integrate it into the current showcase.
My current solution is iframe, but I need to verify that it will work as expected.