### PR TITLE
use same labels for mobile menu

### DIFF
--- a/projects/showcase/src/app/shared/layout/layout.component.ts
+++ b/projects/showcase/src/app/shared/layout/layout.component.ts
@@ -35,8 +35,8 @@ import { MatMenuModule } from '@angular/material/menu';
         </button>
 
         <mat-menu #mobileMenu="matMenu">
-          <a mat-menu-item routerLink="/demo"> Demo </a>
-          <a mat-menu-item routerLink="/doc"> Documentation </a>
+          <a mat-menu-item routerLink="/demo"> Examples </a>
+          <a mat-menu-item routerLink="/doc"> API </a>
         </mat-menu>
       </div>
     </mat-toolbar>


### PR DESCRIPTION
Mobile menu

![CleanShot 2024-04-09 at 14 15 35](https://github.com/maplibre/ngx-maplibre-gl/assets/8985933/7b317265-81af-49de-9fde-a10ac8245c98)

Desktop menu

![CleanShot 2024-04-09 at 14 15 49](https://github.com/maplibre/ngx-maplibre-gl/assets/8985933/8bfd9278-79a4-4a94-9544-18d6885c4720)

