### PR TITLE
remove unused polyfill fix, remove from stackblitz too

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://maplibre.org/ngx-maplibre-gl/
 
 ### Attribution
 
-This is a fork of [ngx-mapbox-gl](https://github.com/Wykks/ngx-mapbox-gl) and I would like to thank the maintainers there for thier amazing work to build this up. It's truely a great piece of sotware!
+This is a fork of [ngx-mapbox-gl](https://github.com/Wykks/ngx-mapbox-gl) and I would like to thank the maintainers there for thier amazing work to build this up. It's truely a great piece of software!
 
 ### API Documentation
 

--- a/README.md
+++ b/README.md
@@ -57,12 +57,6 @@ Or in the global CSS file (called `styles.css` for example in _angular-cli_):
 @import '~maplibre-gl/dist/maplibre-gl.css';
 ```
 
-Add this in your polyfill.ts file (https://github.com/Wykks/ngx-mapbox-gl/issues/136#issuecomment-496224634):
-
-```
-(window as any).global = window;
-```
-
 Then, in your app's main module (or in any other module), import the `MapComponent`:
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://maplibre.org/ngx-maplibre-gl/
 
 ### Attribution
 
-This is a fork of [ngx-mapbox-gl](https://github.com/Wykks/ngx-mapbox-gl) and I would like to thank the maintainers there for thier amazing work to build this up. It's truely a great piece of software!
+This is a fork of [ngx-mapbox-gl](https://github.com/Wykks/ngx-mapbox-gl) and I would like to thank the maintainers there for their amazing work to build this up. It's truly a great piece of software!
 
 ### API Documentation
 

--- a/projects/showcase/src/app/demo/stackblitz-edit/create-stackblitz-project.ts
+++ b/projects/showcase/src/app/demo/stackblitz-edit/create-stackblitz-project.ts
@@ -30,10 +30,7 @@ html, body {
   margin: 0;
 }
 `,
-      'src/polyfills.ts': `
-import 'zone.js';
-(window as any).global = window;
-`,
+      'src/polyfills.ts': `import 'zone.js';`,
       ...demoFiles,
     },
     title: '',

--- a/projects/showcase/src/assets/stackblitz/main.notts
+++ b/projects/showcase/src/assets/stackblitz/main.notts
@@ -1,4 +1,4 @@
-import './polyfills';
+
 import { bootstrapApplication } from '@angular/platform-browser';
 import { ### } from './demo';
 


### PR DESCRIPTION
Seems like maplibre-gl and ngx-maplibre-gl do not rely on this fix anymore:

```
(window as any).global = window;
```

I removed it from the showcase app (https://github.com/maplibre/ngx-maplibre-gl/pull/157/commits/05b5424abb260646da6eed558871f91593f82770) and the map works as expected.

This removes it from the README "How to start" and from Stackblitz examples, simplifying the setup for new angular developers.