### PR TITLE
draft: move to signal

### DIFF
--- a/projects/ngx-maplibre-gl/package.json
+++ b/projects/ngx-maplibre-gl/package.json
@@ -20,8 +20,8 @@
   },
   "homepage": "https://github.com/maplibre/ngx-maplibre-gl#readme",
   "peerDependencies": {
-    "@angular/common": ">= 17.0.0",
-    "@angular/core": ">= 17.0.0",
+    "@angular/common": ">= 17.1.0",
+    "@angular/core": ">= 17.1.0",
     "maplibre-gl": ">= 3.6.0",
     "rxjs": ">= 7.8.1"
   }

--- a/projects/ngx-maplibre-gl/src/lib/control/attribution-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/attribution-control.directive.ts
@@ -1,4 +1,4 @@
-import { AfterContentInit, Directive, Host, Input } from '@angular/core';
+import { AfterContentInit, Directive, Host, input } from '@angular/core';
 import { AttributionControl } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
 import { ControlComponent } from './control.component';
@@ -17,9 +17,9 @@ import { ControlComponent } from './control.component';
 })
 export class AttributionControlDirective implements AfterContentInit {
   /** Init input */
-  @Input() compact?: boolean;
+  compact = input<boolean>();
   /** Init input */
-  @Input() customAttribution?: string | string[];
+  customAttribution = input<string | string[]>();
 
   constructor(
     private mapService: MapService,
@@ -35,16 +35,16 @@ export class AttributionControlDirective implements AfterContentInit {
         compact?: boolean;
         customAttribution?: string | string[];
       } = {};
-      if (this.compact !== undefined) {
-        options.compact = this.compact;
+      if (this.compact() !== undefined) {
+        options.compact = this.compact();
       }
-      if (this.customAttribution !== undefined) {
-        options.customAttribution = this.customAttribution;
+      if (this.customAttribution() !== undefined) {
+        options.customAttribution = this.customAttribution();
       }
       this.controlComponent.control = new AttributionControl(options);
       this.mapService.addControl(
         this.controlComponent.control,
-        this.controlComponent.position
+        this.controlComponent.position()
       );
     });
   }

--- a/projects/ngx-maplibre-gl/src/lib/control/control.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/control.component.ts
@@ -2,10 +2,10 @@ import {
   ChangeDetectionStrategy,
   Component,
   ElementRef,
-  Input,
   OnDestroy,
   ViewChild,
-  afterNextRender
+  afterNextRender,
+  input
 } from '@angular/core';
 import { ControlPosition, IControl } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
@@ -59,7 +59,7 @@ export class CustomControl implements IControl {
 })
 export class ControlComponent<T extends IControl> implements OnDestroy {
   /** Init input */
-  @Input() position?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+  position = input<'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'>();
   /** @hidden */
   @ViewChild('content', { static: true }) content: ElementRef;
 
@@ -70,7 +70,7 @@ export class ControlComponent<T extends IControl> implements OnDestroy {
       if (this.content.nativeElement.childNodes.length) {
         this.control = new CustomControl(this.content.nativeElement);
         this.mapService.mapCreated$.subscribe(() => {
-          this.mapService.addControl(this.control!, this.position);
+          this.mapService.addControl(this.control!, this.position());
         });
       }
     });

--- a/projects/ngx-maplibre-gl/src/lib/control/fullscreen-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/fullscreen-control.directive.ts
@@ -3,7 +3,7 @@ import {
   Directive,
   Host,
   HostListener,
-  Input,
+  input
 } from '@angular/core';
 import { FullscreenControl } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
@@ -20,7 +20,7 @@ import { ControlComponent } from './control.component';
 })
 export class FullscreenControlDirective implements AfterContentInit {
   /* Init inputs */
-  @Input() container?: HTMLElement;
+  container = input<HTMLElement>();
   @HostListener('window:webkitfullscreenchange', ['$event.target'])
   onFullscreen() {
     this.mapService.mapInstance.resize();
@@ -37,11 +37,11 @@ export class FullscreenControlDirective implements AfterContentInit {
         throw new Error('Another control is already set for this control');
       }
       this.controlComponent.control = new FullscreenControl({
-        container: this.container,
+        container: this.container(),
       });
       this.mapService.addControl(
         this.controlComponent.control,
-        this.controlComponent.position
+        this.controlComponent.position()
       );
     });
   }

--- a/projects/ngx-maplibre-gl/src/lib/control/geolocate-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/geolocate-control.directive.ts
@@ -3,13 +3,13 @@ import {
   Directive,
   EventEmitter,
   Host,
-  Input,
+  input,
   Output,
 } from '@angular/core';
 import { FitBoundsOptions, GeolocateControl } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
-import { ControlComponent } from './control.component';
 import { Position } from '../map/map.types';
+import { ControlComponent } from './control.component';
 
 /**
  * `mglGeolocate` - a geolocate control directive
@@ -25,10 +25,10 @@ import { Position } from '../map/map.types';
 })
 export class GeolocateControlDirective implements AfterContentInit {
   /* Init inputs */
-  @Input() positionOptions?: PositionOptions;
-  @Input() fitBoundsOptions?: FitBoundsOptions;
-  @Input() trackUserLocation?: boolean;
-  @Input() showUserLocation?: boolean;
+  positionOptions = input<PositionOptions>();
+  fitBoundsOptions = input<FitBoundsOptions>();
+  trackUserLocation = input<boolean>();
+  showUserLocation = input<boolean>();
 
   @Output()
   geolocate: EventEmitter<Position> = new EventEmitter<Position>();
@@ -44,10 +44,10 @@ export class GeolocateControlDirective implements AfterContentInit {
         throw new Error('Another control is already set for this control');
       }
       const options = {
-        positionOptions: this.positionOptions,
-        fitBoundsOptions: this.fitBoundsOptions,
-        trackUserLocation: this.trackUserLocation,
-        showUserLocation: this.showUserLocation,
+        positionOptions: this.positionOptions(),
+        fitBoundsOptions: this.fitBoundsOptions(),
+        trackUserLocation: this.trackUserLocation(),
+        showUserLocation: this.showUserLocation(),
       };
 
       Object.keys(options).forEach((key: string) => {
@@ -62,7 +62,7 @@ export class GeolocateControlDirective implements AfterContentInit {
       });
       this.mapService.addControl(
         this.controlComponent.control,
-        this.controlComponent.position
+        this.controlComponent.position()
       );
     });
   }

--- a/projects/ngx-maplibre-gl/src/lib/control/navigation-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/navigation-control.directive.ts
@@ -1,4 +1,4 @@
-import { AfterContentInit, Directive, Host, Input } from '@angular/core';
+import { AfterContentInit, Directive, Host, input } from '@angular/core';
 import { NavigationControl } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
 import { ControlComponent } from './control.component';
@@ -17,9 +17,9 @@ import { ControlComponent } from './control.component';
 })
 export class NavigationControlDirective implements AfterContentInit {
   /* Init inputs */
-  @Input() showCompass?: boolean;
-  @Input() showZoom?: boolean;
-  @Input() visualizePitch?: boolean;
+  showCompass = input<boolean>();
+  showZoom = input<boolean>();
+  visualizePitch = input<boolean>();
 
   constructor(
     private mapService: MapService,
@@ -38,22 +38,22 @@ export class NavigationControlDirective implements AfterContentInit {
         visualizePitch?: boolean;
       } = {};
 
-      if (this.showCompass !== undefined) {
-        options.showCompass = this.showCompass;
+      if (this.showCompass() !== undefined) {
+        options.showCompass = this.showCompass();
       }
 
-      if (this.showZoom !== undefined) {
-        options.showZoom = this.showZoom;
+      if (this.showZoom() !== undefined) {
+        options.showZoom = this.showZoom();
       }
 
-      if (this.visualizePitch != undefined) {
-        options.visualizePitch = this.visualizePitch;
+      if (this.visualizePitch() !== undefined) {
+        options.visualizePitch = this.visualizePitch();
       }
 
       this.controlComponent.control = new NavigationControl(options);
       this.mapService.addControl(
         this.controlComponent.control,
-        this.controlComponent.position
+        this.controlComponent.position()
       );
     });
   }

--- a/projects/ngx-maplibre-gl/src/lib/control/scale-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/scale-control.directive.ts
@@ -2,7 +2,7 @@ import {
   AfterContentInit,
   Directive,
   Host,
-  Input,
+  input,
   OnChanges,
   SimpleChanges,
 } from '@angular/core';
@@ -24,10 +24,10 @@ import { ControlComponent } from './control.component';
 })
 export class ScaleControlDirective implements AfterContentInit, OnChanges {
   /* Init inputs */
-  @Input() maxWidth?: number;
+  maxWidth = input<number>();
 
   /* Dynamic inputs */
-  @Input() unit?: 'imperial' | 'metric' | 'nautical';
+  unit = input<'imperial' | 'metric' | 'nautical'>();
 
   constructor(
     private mapService: MapService,
@@ -48,16 +48,16 @@ export class ScaleControlDirective implements AfterContentInit, OnChanges {
         throw new Error('Another control is already set for this control');
       }
       const options: ScaleControlOptions = {};
-      if (this.maxWidth !== undefined) {
-        options.maxWidth = this.maxWidth;
+      if (this.maxWidth() !== undefined) {
+        options.maxWidth = this.maxWidth();
       }
-      if (this.unit !== undefined) {
-        options.unit = this.unit;
+      if (this.unit() !== undefined) {
+        options.unit = this.unit();
       }
       this.controlComponent.control = new ScaleControl(options);
       this.mapService.addControl(
         this.controlComponent.control,
-        this.controlComponent.position
+        this.controlComponent.position()
       );
     });
   }

--- a/projects/ngx-maplibre-gl/src/lib/control/terrain-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/terrain-control.directive.ts
@@ -1,4 +1,4 @@
-import { AfterContentInit, Directive, Host, Input } from '@angular/core';
+import { AfterContentInit, Directive, Host, input } from '@angular/core';
 import { TerrainControl, TerrainSpecification } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
 import { ControlComponent } from './control.component';
@@ -17,8 +17,8 @@ import { ControlComponent } from './control.component';
 })
 export class TerrainControlDirective implements AfterContentInit {
   /* Init inputs */
-  @Input() source: string;
-  @Input() exaggeration?: number;
+  source = input.required<string>();
+  exaggeration = input<number>();
 
   constructor(
     private mapService: MapService,
@@ -32,15 +32,15 @@ export class TerrainControlDirective implements AfterContentInit {
       }
 
       const options: TerrainSpecification = {
-        source: this.source,
-        exaggeration: this.exaggeration ?? 1,
+        source: this.source(),
+        exaggeration: this.exaggeration() ?? 1,
       };
 
       this.controlComponent.control = new TerrainControl(options);
 
       this.mapService.addControl(
         this.controlComponent.control,
-        this.controlComponent.position
+        this.controlComponent.position()
       );
     });
   }

--- a/projects/ngx-maplibre-gl/src/lib/draggable/draggable.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/draggable/draggable.directive.ts
@@ -2,15 +2,15 @@ import {
   Directive,
   EventEmitter,
   Host,
-  Input,
   NgZone,
   OnDestroy,
   OnInit,
   Optional,
   Output,
+  input
 } from '@angular/core';
 import { MapMouseEvent } from 'maplibre-gl';
-import { fromEvent, Observable, Subscription } from 'rxjs';
+import { Observable, Subscription, fromEvent } from 'rxjs';
 import { filter, switchMap, take, takeUntil, tap } from 'rxjs/operators';
 import { LayerComponent } from '../layer/layer.component';
 import { MapService } from '../map/map.service';
@@ -29,7 +29,7 @@ import { FeatureComponent } from '../source/geojson/feature.component';
 })
 export class DraggableDirective implements OnInit, OnDestroy {
   // eslint-disable-next-line @angular-eslint/no-input-rename
-  @Input('mglDraggable') layer?: LayerComponent;
+  layer = input<LayerComponent | undefined>(undefined, { alias: 'mglDraggable' });
 
   @Output() featureDragStart = new EventEmitter<MapMouseEvent>();
   @Output() featureDragEnd = new EventEmitter<MapMouseEvent>();
@@ -47,9 +47,9 @@ export class DraggableDirective implements OnInit, OnDestroy {
     let enter$;
     let leave$;
     let updateCoords;
-    if (this.featureComponent && this.layer) {
-      enter$ = this.layer.layerMouseEnter;
-      leave$ = this.layer.layerMouseLeave;
+    if (this.featureComponent && this.layer()) {
+      enter$ = this.layer()!.layerMouseEnter;
+      leave$ = this.layer()!.layerMouseLeave;
       updateCoords = this.featureComponent.updateCoordinates.bind(
         this.featureComponent
       );
@@ -155,11 +155,11 @@ export class DraggableDirective implements OnInit, OnDestroy {
   }
 
   private filterFeature(evt: MapMouseEvent) {
-    if (this.featureComponent && this.layer) {
+    if (this.featureComponent && this.layer()) {
       const feature: GeoJSON.Feature = this.mapService.queryRenderedFeatures(
         evt.point,
         {
-          layers: [this.layer.id],
+          layers: [this.layer()!.id()],
           filter: [
             'all',
             ['==', '$type', 'Point'],

--- a/projects/ngx-maplibre-gl/src/lib/image/image.component.spec.ts
+++ b/projects/ngx-maplibre-gl/src/lib/image/image.component.spec.ts
@@ -1,4 +1,4 @@
-import { SimpleChange } from '@angular/core';
+import { SimpleChange, signal } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { of } from 'rxjs';
 import { MapService } from '../map/map.service';
@@ -36,29 +36,29 @@ describe('ImageComponent', () => {
     fixture = TestBed.createComponent(ImageComponent);
     component = fixture.componentInstance;
     msSpy = fixture.debugElement.injector.get<MapService>(MapService) as any;
-    component.id = 'imageId';
+    component.id = signal('imageId') as unknown as typeof fixture.componentInstance.id;
   });
 
   describe('Init/Destroy tests', () => {
     it('should init with custom inputs', () => {
-      component.data = {
+      component.data = signal({
         width: 500,
         height: 500,
         data: new Uint8Array([5, 5]),
-      };
+      }) as unknown as typeof fixture.componentInstance.data;
       fixture.detectChanges();
       expect(msSpy.addImage).toHaveBeenCalled();
     });
 
     it('should remove image on destroy', () => {
-      component.data = {
+      component.data = signal({
         width: 500,
         height: 500,
         data: new Uint8Array([5, 5]),
-      };
+      }) as unknown as typeof fixture.componentInstance.data;
       fixture.detectChanges();
       component.ngOnDestroy();
-      expect(msSpy.removeImage).toHaveBeenCalledWith(component.id);
+      expect(msSpy.removeImage).toHaveBeenCalledWith(component.id());
     });
 
     it('should not remove image on destroy if not added', () => {
@@ -69,17 +69,17 @@ describe('ImageComponent', () => {
 
   describe('Change tests', () => {
     it('should update image', () => {
-      component.id = 'layerId';
-      component.data = {
+      component.id = signal('layerId') as unknown as typeof fixture.componentInstance.id;
+      component.data = signal({
         width: 500,
         height: 500,
         data: new Uint8Array([5, 5]),
-      };
+      }) as unknown as typeof fixture.componentInstance.data;
       fixture.detectChanges();
       component.ngOnChanges({
-        data: new SimpleChange(null, component.data, false),
+        data: new SimpleChange(null, component.data(), false),
       });
-      expect(msSpy.removeImage).toHaveBeenCalledWith(component.id);
+      expect(msSpy.removeImage).toHaveBeenCalledWith(component.id());
       expect(msSpy.addImage).toHaveBeenCalled();
     });
   });

--- a/projects/ngx-maplibre-gl/src/lib/image/image.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/image/image.component.ts
@@ -1,7 +1,7 @@
 import {
   Component,
   EventEmitter,
-  Input,
+  input,
   NgZone,
   OnChanges,
   OnDestroy,
@@ -52,14 +52,14 @@ import { MapImageData, MapImageOptions } from '../map/map.types';
 })
 export class ImageComponent implements OnInit, OnDestroy, OnChanges {
   /** Init input */
-  @Input() id: string;
+  id = input.required<string>();
 
   /** Dynamic input */
-  @Input() data?: MapImageData;
+  data = input<MapImageData>();
   /** Dynamic input */
-  @Input() options?: MapImageOptions;
+  options = input<MapImageOptions>();
   /** Dynamic input */
-  @Input() url?: string;
+  url = input<string>();
 
   @Output() imageError = new EventEmitter<{ status: number }>();
   @Output() imageLoaded = new EventEmitter<void>();
@@ -68,7 +68,7 @@ export class ImageComponent implements OnInit, OnDestroy, OnChanges {
   private isAdding = false;
   private sub: Subscription;
 
-  constructor(private mapService: MapService, private zone: NgZone) {}
+  constructor(private mapService: MapService, private zone: NgZone) { }
 
   ngOnInit() {
     this.sub = this.mapService.mapLoaded$
@@ -78,7 +78,7 @@ export class ImageComponent implements OnInit, OnDestroy, OnChanges {
             startWith(undefined),
             filter(
               () =>
-                !this.isAdding && !this.mapService.mapInstance.hasImage(this.id)
+                !this.isAdding && !this.mapService.mapInstance.hasImage(this.id())
             )
           )
         )
@@ -99,7 +99,7 @@ export class ImageComponent implements OnInit, OnDestroy, OnChanges {
 
   ngOnDestroy() {
     if (this.isAdded) {
-      this.mapService.removeImage(this.id);
+      this.mapService.removeImage(this.id());
     }
     if (this.sub) {
       this.sub.unsubscribe();
@@ -108,13 +108,13 @@ export class ImageComponent implements OnInit, OnDestroy, OnChanges {
 
   private async init() {
     this.isAdding = true;
-    if (this.data) {
-      this.mapService.addImage(this.id, this.data, this.options);
+    if (this.data()) {
+      this.mapService.addImage(this.id(), this.data()!, this.options());
       this.isAdded = true;
       this.isAdding = false;
-    } else if (this.url) {
+    } else if (this.url()) {
       try {
-        await this.mapService.loadAndAddImage(this.id, this.url, this.options);
+        await this.mapService.loadAndAddImage(this.id(), this.url() ?? '', this.options());
         this.isAdded = true;
         this.isAdding = false;
         this.zone.run(() => {

--- a/projects/ngx-maplibre-gl/src/lib/layer/layer.component.spec.ts
+++ b/projects/ngx-maplibre-gl/src/lib/layer/layer.component.spec.ts
@@ -1,4 +1,4 @@
-import { SimpleChange } from '@angular/core';
+import { SimpleChange, signal } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { of } from 'rxjs';
 import { MapService, SetupLayer } from '../map/map.service';
@@ -39,16 +39,16 @@ describe('LayerComponent', () => {
     fixture = TestBed.createComponent(LayerComponent);
     component = fixture.componentInstance;
     msSpy = fixture.debugElement.injector.get<MapService>(MapService) as any;
-    component.id = 'layerId';
+    component.id = signal('layerId') as unknown as typeof fixture.componentInstance.id;
   });
 
   describe('Init/Destroy tests', () => {
     it('should init with custom inputs', (done: DoneFn) => {
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      component.paint = { 'background-color': 'green' };
-      component.type = 'background';
+      component.paint = signal({ 'background-color': 'green' }) as unknown as typeof fixture.componentInstance.paint;
+      component.type = signal('background') as unknown as typeof fixture.componentInstance.type;
       msSpy.addLayer.and.callFake((options: SetupLayer) => {
-        expect(options.layerOptions.id).toEqual(component.id);
+        expect(options.layerOptions.id).toEqual(component.id());
         expect((options.layerOptions as any).paint['background-color']).toEqual(
           'green'
         );
@@ -59,21 +59,21 @@ describe('LayerComponent', () => {
 
     it('should remove layer on destroy', () => {
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      component.paint = { 'background-color': 'green' };
+      component.paint = signal({ 'background-color': 'green' }) as unknown as typeof fixture.componentInstance.paint;
       fixture.detectChanges();
       component.ngOnDestroy();
-      expect(msSpy.removeLayer).toHaveBeenCalledWith(component.id);
+      expect(msSpy.removeLayer).toHaveBeenCalledWith(component.id());
     });
 
     it('should remove layer and source on destroy', () => {
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      component.paint = { 'background-color': 'green' };
-      component.removeSource = true;
-      msSpy.getSource.and.returnValues(undefined, component.id, {});
+      component.paint = signal({ 'background-color': 'green' }) as unknown as typeof fixture.componentInstance.paint;
+      component.removeSource = signal(true) as unknown as typeof fixture.componentInstance.removeSource;
+      msSpy.getSource.and.returnValues(undefined, component.id(), {});
       fixture.detectChanges();
       component.ngOnDestroy();
-      expect(msSpy.removeLayer).toHaveBeenCalledWith(component.id);
-      expect(msSpy.removeSource).toHaveBeenCalledWith(component.id);
+      expect(msSpy.removeLayer).toHaveBeenCalledWith(component.id());
+      expect(msSpy.removeSource).toHaveBeenCalledWith(component.id());
     });
 
     it('should not remove layer on destroy if not added', () => {
@@ -84,20 +84,20 @@ describe('LayerComponent', () => {
 
   describe('Change tests', () => {
     it('should update paint', () => {
-      component.id = 'layerId';
-      component.paint = {
+      component.id = signal('layerId') as unknown as typeof fixture.componentInstance.id;
+      component.paint = signal({
         // eslint-disable-next-line @typescript-eslint/naming-convention
         'background-color': 'green',
         // eslint-disable-next-line @typescript-eslint/naming-convention
         'background-opacity': 0.5,
-      };
+      }) as unknown as typeof fixture.componentInstance.paint;
       fixture.detectChanges();
       component.ngOnChanges({
-        paint: new SimpleChange(null, component.paint, false),
+        paint: new SimpleChange(null, component.paint(), false),
       });
       expect(msSpy.setAllLayerPaintProperty).toHaveBeenCalledWith(
-        component.id,
-        component.paint
+        component.id(),
+        component.paint()
       );
     });
   });

--- a/projects/ngx-maplibre-gl/src/lib/layer/layer.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/layer/layer.component.ts
@@ -1,7 +1,7 @@
 import {
   Component,
   EventEmitter,
-  Input,
+  input,
   OnChanges,
   OnDestroy,
   OnInit,
@@ -9,8 +9,8 @@ import {
   SimpleChanges,
 } from '@angular/core';
 import {
-  LayerSpecification,
   FilterSpecification,
+  LayerSpecification,
   MapLayerMouseEvent,
   MapLayerTouchEvent,
 } from 'maplibre-gl';
@@ -49,34 +49,34 @@ import { EventData, LayerEvents } from '../map/map.types';
 export class LayerComponent
   implements OnInit, OnDestroy, OnChanges, LayerEvents {
   /** Init input */
-  @Input() id: LayerSpecification['id'];
+  id = input.required<LayerSpecification['id']>();
   /** Init input */
-  @Input() source?: string;
+  source = input<string>();
   /** Init input */
-  @Input() type: LayerSpecification['type'];
+  type = input.required<LayerSpecification['type']>();
   /** Init input */
-  @Input() metadata?: LayerSpecification['metadata'];
+  metadata = input<LayerSpecification['metadata']>();
   /** Init input */
-  @Input() sourceLayer?: string;
+  sourceLayer = input<string>();
   /**
    * A flag to enable removeSource clean up functionality
    * 
    * Init input
    */
-  @Input() removeSource?: boolean;
+  removeSource = input<boolean>();
 
   /** Dynamic input */
-  @Input() filter?: FilterSpecification;
+  filter = input<FilterSpecification>();
   /** Dynamic input */
-  @Input() layout?: LayerSpecification['layout'];
+  layout = input<LayerSpecification['layout']>();
   /** Dynamic input */
-  @Input() paint?: LayerSpecification['paint'];
+  paint = input<LayerSpecification['paint']>();
   /** Dynamic input */
-  @Input() before?: string;
+  before = input<string>();
   /** Dynamic input */
-  @Input() minzoom?: LayerSpecification['minzoom'];
+  minzoom = input<LayerSpecification['minzoom']>();
   /** Dynamic input */
-  @Input() maxzoom?: LayerSpecification['maxzoom'];
+  maxzoom = input<LayerSpecification['maxzoom']>();
 
   @Output() layerClick = new EventEmitter<MapLayerMouseEvent & EventData>();
   @Output() layerDblClick = new EventEmitter<MapLayerMouseEvent & EventData>();
@@ -114,7 +114,7 @@ export class LayerComponent
         switchMap(() =>
           fromEvent(this.mapService.mapInstance, 'styledata').pipe(
             map(() => false),
-            filter(() => !this.mapService.mapInstance.getLayer(this.id)),
+            filter(() => !this.mapService.mapInstance.getLayer(this.id())),
             startWith(true)
           )
         )
@@ -128,33 +128,33 @@ export class LayerComponent
     }
     if (changes.paint && !changes.paint.isFirstChange()) {
       this.mapService.setAllLayerPaintProperty(
-        this.id,
+        this.id(),
         changes.paint.currentValue!
       );
     }
     if (changes.layout && !changes.layout.isFirstChange()) {
       this.mapService.setAllLayerLayoutProperty(
-        this.id,
+        this.id(),
         changes.layout.currentValue!
       );
     }
     if (changes.filter && !changes.filter.isFirstChange()) {
-      this.mapService.setLayerFilter(this.id, changes.filter.currentValue!);
+      this.mapService.setLayerFilter(this.id(), changes.filter.currentValue!);
     }
     if (changes.before && !changes.before.isFirstChange()) {
-      this.mapService.setLayerBefore(this.id, changes.before.currentValue!);
+      this.mapService.setLayerBefore(this.id(), changes.before.currentValue!);
     }
     if (
       (changes.minzoom && !changes.minzoom.isFirstChange()) ||
       (changes.maxzoom && !changes.maxzoom.isFirstChange())
     ) {
-      this.mapService.setLayerZoomRange(this.id, this.minzoom, this.maxzoom);
+      this.mapService.setLayerZoomRange(this.id(), this.minzoom(), this.maxzoom());
     }
   }
 
   ngOnDestroy() {
     if (this.layerAdded) {
-      this.mapService.removeLayer(this.id);
+      this.mapService.removeLayer(this.id());
       if (undefined !== this.sourceIdAdded) {
         // Clean up any automatically created source for this layer
         if (this.mapService.getSource(this.sourceIdAdded)) {
@@ -170,17 +170,17 @@ export class LayerComponent
   private init(bindEvents: boolean) {
     const layer: SetupLayer = {
       layerOptions: {
-        id: this.id,
-        type: this.type,
-        source: this.source as string,
-        metadata: this.metadata,
+        id: this.id(),
+        type: this.type(),
+        source: this.source(),
+        metadata: this.metadata(),
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        'source-layer': this.sourceLayer,
-        minzoom: this.minzoom,
-        maxzoom: this.maxzoom,
-        filter: this.filter,
-        layout: this.layout,
-        paint: this.paint,
+        'source-layer': this.sourceLayer(),
+        minzoom: this.minzoom(),
+        maxzoom: this.maxzoom(),
+        filter: this.filter(),
+        layout: this.layout(),
+        paint: this.paint(),
       } as LayerSpecification,
       layerEvents: {
         layerClick: this.layerClick,
@@ -198,14 +198,14 @@ export class LayerComponent
         layerTouchCancel: this.layerTouchCancel,
       },
     };
-    if (this.removeSource && typeof this.source !== 'string') {
+    if (this.removeSource() && typeof this.source() !== 'string') {
       // There is no id of an existing source bound to this layer
-      if (undefined === this.mapService.getSource(this.id)) {
+      if (undefined === this.mapService.getSource(this.id())) {
         // A source with this layer id doesn't exist so it will be created automatically in the addLayer call below
-        this.sourceIdAdded = this.id;
+        this.sourceIdAdded = this.id();
       }
     }
-    this.mapService.addLayer(layer, bindEvents, this.before);
+    this.mapService.addLayer(layer, bindEvents, this.before());
     if (undefined !== this.sourceIdAdded) {
       if (undefined === this.mapService.getSource(this.sourceIdAdded)) {
         // If it wasn't created for some reason then we don't want to clean it up


### PR DESCRIPTION
Signal `input` are available as a replacement for `@Input` since angular 17.1

This PR is about replacing `@Input` by `input`. It will be compatible with angular >= 17.1