### PR TITLE
show node_modules, useful to inspect installed packages

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,6 @@
     "**/.hg": true,
     "**/CVS": true,
     "**/.DS_Store": true,
-    "**/node_modules/**": true,
     ".ng_build": true
   },
   "typescript.tsdk": "node_modules/typescript/lib",


### PR DESCRIPTION
While upgrading to SSR I had to inspect packages in node_modules. However, they are hidden in VSCode. I think it is useful to show the directory for inspecting installed packages.