### PR TITLE
change build and test to run on ubuntu, update ci action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Node.js from .nvmrc file
         uses: actions/setup-node@v4
@@ -24,11 +24,11 @@ jobs:
         run: npm run lint
   build-and-test:
     # The type of runner that the job will run on
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Node.js from .nvmrc file
         uses: actions/setup-node@v4
@@ -54,7 +54,7 @@ jobs:
         run: npm run e2e
 
       - name: Upload Cypress Videos
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cypress-artifacts
           path: cypress/videos


### PR DESCRIPTION
Change `build-and-test` job to run on `ubuntu-latest` instead of `macos-latest`. 
Any particular reason `macos-latest` was used in this step?

Update also `actions/checkout` and `actions/upload-artifact` to latest version.