### PR TITLE
Angular 18 zoneless showcase

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -60,7 +60,7 @@
             "outputPath": "dist/showcase",
             "index": "projects/showcase/src/index.html",
             "browser": "projects/showcase/src/main.ts",
-            "polyfills": ["zone.js"],
+            "polyfills": [],
             "tsConfig": "projects/showcase/tsconfig.app.json",
             "assets": [
               "projects/showcase/src/favicon.ico",

--- a/projects/showcase/src/app/app.config.ts
+++ b/projects/showcase/src/app/app.config.ts
@@ -1,4 +1,7 @@
-import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import {
+  ApplicationConfig,
+  provideExperimentalZonelessChangeDetection,
+} from '@angular/core';
 import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
@@ -8,7 +11,7 @@ import { provideClientHydration } from '@angular/platform-browser';
 
 export const appConfig: ApplicationConfig = {
   providers: [
-    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideExperimentalZonelessChangeDetection(),
     provideRouter(routes),
     provideHttpClient(withFetch()),
     provideAnimations(),


### PR DESCRIPTION
Enables experimental zoneless for the showcase app. The map is not rendered at all, even though it uses `ChangeDetectionStrategy.OnPush`. OnPush is not enough to notify the map to render.

https://angular.dev/guide/experimental/zoneless#onpush-compatible-components
https://blog.angular.dev/angular-v18-is-now-available-e79d5ac0affe
![CleanShot 2024-06-06 at 10 16 42](https://github.com/maplibre/ngx-maplibre-gl/assets/8985933/48b6d3e2-5ce4-4eae-af16-0e435fd5551f)
