### PR TITLE
feat: Migrate decorators to signal queries

### DIFF
--- a/projects/ngx-maplibre-gl/src/lib/control/attribution-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/attribution-control.directive.ts
@@ -1,13 +1,13 @@
-import { AfterContentInit, Directive, Host, Input } from '@angular/core';
+import { AfterContentInit, Directive, Input, inject } from '@angular/core';
 import { AttributionControl } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
 import { ControlComponent } from './control.component';
 
 /**
  * `mglAttribution` - an attribution control directive
- * 
+ *
  * @category Directives
- * 
+ *
  * @see [Add custom attribution](https://maplibre.org/ngx-maplibre-gl/demo/custom-attribution)
  * @see [AttributionControl](https://maplibre.org/maplibre-gl-js/docs/API/classes/AttributionControl)
  */
@@ -16,15 +16,16 @@ import { ControlComponent } from './control.component';
   standalone: true,
 })
 export class AttributionControlDirective implements AfterContentInit {
+  /* Init injection */
+  private readonly mapService = inject(MapService);
+  private readonly controlComponent = inject<
+    ControlComponent<AttributionControl>
+  >(ControlComponent, { host: true });
+
   /** Init input */
   @Input() compact?: boolean;
   /** Init input */
   @Input() customAttribution?: string | string[];
-
-  constructor(
-    private mapService: MapService,
-    @Host() private controlComponent: ControlComponent<AttributionControl>
-  ) {}
 
   ngAfterContentInit() {
     this.mapService.mapCreated$.subscribe(() => {

--- a/projects/ngx-maplibre-gl/src/lib/control/attribution-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/attribution-control.directive.ts
@@ -5,7 +5,7 @@ import {
 } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
 import { ControlComponent } from './control.component';
-import { keepAvailableObjectValues } from '../shared/utils';
+import { keepAvailableObjectValues } from '../shared/utils/functions/object.fn';
 
 /**
  * `mglAttribution` - an attribution control directive
@@ -28,6 +28,7 @@ export class AttributionControlDirective {
 
   /** Init input */
   readonly compact = input<boolean>();
+  /** Init input */
   readonly customAttribution = input<string | string[]>();
 
   constructor() {

--- a/projects/ngx-maplibre-gl/src/lib/control/attribution-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/attribution-control.directive.ts
@@ -1,7 +1,11 @@
 import { Directive, afterNextRender, inject, input } from '@angular/core';
-import { AttributionControl } from 'maplibre-gl';
+import {
+  AttributionControl,
+  type AttributionControlOptions,
+} from 'maplibre-gl';
 import { MapService } from '../map/map.service';
 import { ControlComponent } from './control.component';
+import { keepAvailableObjectValues } from '../shared/utils';
 
 /**
  * `mglAttribution` - an attribution control directive
@@ -32,19 +36,12 @@ export class AttributionControlDirective {
         if (this.controlComponent.control) {
           throw new Error('Another control is already set for this control');
         }
-        const options: {
-          compact?: boolean;
-          customAttribution?: string | string[];
-        } = {};
-        const compact = this.compact();
 
-        if (compact !== undefined) {
-          options.compact = compact;
-        }
-        const customAttribution = this.customAttribution();
-        if (customAttribution !== undefined) {
-          options.customAttribution = customAttribution;
-        }
+        const options = keepAvailableObjectValues<AttributionControlOptions>({
+          compact: this.compact(),
+          customAttribution: this.customAttribution(),
+        });
+
         this.controlComponent.control = new AttributionControl(options);
         this.mapService.addControl(
           this.controlComponent.control,

--- a/projects/ngx-maplibre-gl/src/lib/control/control.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/control.component.ts
@@ -1,11 +1,12 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  DestroyRef,
   ElementRef,
   Input,
-  OnDestroy,
-  ViewChild,
-  afterNextRender
+  afterNextRender,
+  inject,
+  viewChild,
 } from '@angular/core';
 import { ControlPosition, IControl } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
@@ -57,28 +58,32 @@ export class CustomControl implements IControl {
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
 })
-export class ControlComponent<T extends IControl> implements OnDestroy {
+export class ControlComponent<T extends IControl> {
+  /** Init injection */
+  private readonly mapService = inject(MapService);
+  private readonly destroyRef = inject(DestroyRef);
+
   /** Init input */
   @Input() position?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
   /** @hidden */
-  @ViewChild('content', { static: true }) content: ElementRef;
+  content = viewChild.required<ElementRef>('content');
 
   control: T | CustomControl;
 
-  constructor(private mapService: MapService) {
+  constructor() {
     afterNextRender(() => {
-      if (this.content.nativeElement.childNodes.length) {
-        this.control = new CustomControl(this.content.nativeElement);
+      if (this.content().nativeElement.childNodes.length) {
+        this.control = new CustomControl(this.content().nativeElement);
         this.mapService.mapCreated$.subscribe(() => {
           this.mapService.addControl(this.control!, this.position);
         });
       }
     });
-  }
 
-  ngOnDestroy() {
-    if (this.mapService?.mapInstance?.hasControl(this.control)) {
-      this.mapService.removeControl(this.control);
-    }
+    this.destroyRef.onDestroy(() => {
+      if (this.mapService?.mapInstance?.hasControl(this.control)) {
+        this.mapService.removeControl(this.control);
+      }
+    });
   }
 }

--- a/projects/ngx-maplibre-gl/src/lib/control/control.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/control.component.ts
@@ -64,12 +64,10 @@ export class ControlComponent<T extends IControl> {
   private readonly destroyRef = inject(DestroyRef);
 
   /** Init input */
-  readonly position = input<
-    'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
-  >();
+  readonly position = input<ControlPosition>();
 
   /** @hidden */
-  readonly content = viewChild.required<ElementRef>('content');
+  readonly content = viewChild.required<ElementRef<HTMLDivElement>>('content');
 
   control: T | CustomControl;
 

--- a/projects/ngx-maplibre-gl/src/lib/control/control.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/control.component.ts
@@ -3,12 +3,12 @@ import {
   Component,
   DestroyRef,
   ElementRef,
-  Input,
   afterNextRender,
   inject,
+  input,
   viewChild,
 } from '@angular/core';
-import { ControlPosition, IControl } from 'maplibre-gl';
+import type { ControlPosition, IControl } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
 
 export class CustomControl implements IControl {
@@ -64,9 +64,12 @@ export class ControlComponent<T extends IControl> {
   private readonly destroyRef = inject(DestroyRef);
 
   /** Init input */
-  @Input() position?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+  readonly position = input<
+    'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
+  >();
+
   /** @hidden */
-  content = viewChild.required<ElementRef>('content');
+  readonly content = viewChild.required<ElementRef>('content');
 
   control: T | CustomControl;
 
@@ -75,7 +78,7 @@ export class ControlComponent<T extends IControl> {
       if (this.content().nativeElement.childNodes.length) {
         this.control = new CustomControl(this.content().nativeElement);
         this.mapService.mapCreated$.subscribe(() => {
-          this.mapService.addControl(this.control!, this.position);
+          this.mapService.addControl(this.control, this.position());
         });
       }
     });

--- a/projects/ngx-maplibre-gl/src/lib/control/fullscreen-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/fullscreen-control.directive.ts
@@ -1,10 +1,4 @@
-import {
-  AfterContentInit,
-  Directive,
-  HostListener,
-  Input,
-  inject,
-} from '@angular/core';
+import { Directive, afterNextRender, inject, input } from '@angular/core';
 import { FullscreenControl } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
 import { ControlComponent } from './control.component';
@@ -17,8 +11,12 @@ import { ControlComponent } from './control.component';
 @Directive({
   selector: '[mglFullscreen]',
   standalone: true,
+  host: {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    '(window:webkitfullscreenchange)': 'onFullscreen()',
+  },
 })
-export class FullscreenControlDirective implements AfterContentInit {
+export class FullscreenControlDirective {
   /* Init injection */
   private readonly mapService = inject(MapService);
   private readonly controlComponent = inject<
@@ -26,24 +24,26 @@ export class FullscreenControlDirective implements AfterContentInit {
   >(ControlComponent, { host: true });
 
   /* Init inputs */
-  @Input() container?: HTMLElement;
-  @HostListener('window:webkitfullscreenchange', ['$event.target'])
-  onFullscreen() {
-    this.mapService.mapInstance.resize();
+  readonly container = input<HTMLElement>();
+
+  constructor() {
+    afterNextRender(() => {
+      this.mapService.mapCreated$.subscribe(() => {
+        if (this.controlComponent.control) {
+          throw new Error('Another control is already set for this control');
+        }
+        this.controlComponent.control = new FullscreenControl({
+          container: this.container(),
+        });
+        this.mapService.addControl(
+          this.controlComponent.control,
+          this.controlComponent.position()
+        );
+      });
+    });
   }
 
-  ngAfterContentInit() {
-    this.mapService.mapCreated$.subscribe(() => {
-      if (this.controlComponent.control) {
-        throw new Error('Another control is already set for this control');
-      }
-      this.controlComponent.control = new FullscreenControl({
-        container: this.container,
-      });
-      this.mapService.addControl(
-        this.controlComponent.control,
-        this.controlComponent.position
-      );
-    });
+  onFullscreen() {
+    this.mapService.mapInstance.resize();
   }
 }

--- a/projects/ngx-maplibre-gl/src/lib/control/fullscreen-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/fullscreen-control.directive.ts
@@ -1,9 +1,9 @@
 import {
   AfterContentInit,
   Directive,
-  Host,
   HostListener,
   Input,
+  inject,
 } from '@angular/core';
 import { FullscreenControl } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
@@ -11,7 +11,7 @@ import { ControlComponent } from './control.component';
 
 /**
  * `mglFullscreen` - a fullscreen control directive
- * 
+ *
  * @category Directives
  */
 @Directive({
@@ -19,17 +19,18 @@ import { ControlComponent } from './control.component';
   standalone: true,
 })
 export class FullscreenControlDirective implements AfterContentInit {
+  /* Init injection */
+  private readonly mapService = inject(MapService);
+  private readonly controlComponent = inject<
+    ControlComponent<FullscreenControl>
+  >(ControlComponent, { host: true });
+
   /* Init inputs */
   @Input() container?: HTMLElement;
   @HostListener('window:webkitfullscreenchange', ['$event.target'])
   onFullscreen() {
     this.mapService.mapInstance.resize();
   }
-
-  constructor(
-    private mapService: MapService,
-    @Host() private controlComponent: ControlComponent<FullscreenControl>
-  ) {}
 
   ngAfterContentInit() {
     this.mapService.mapCreated$.subscribe(() => {

--- a/projects/ngx-maplibre-gl/src/lib/control/geolocate-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/geolocate-control.directive.ts
@@ -1,14 +1,14 @@
 import {
-  AfterContentInit,
   Directive,
-  Input,
+  afterNextRender,
   inject,
+  input,
   output,
 } from '@angular/core';
-import { FitBoundsOptions, GeolocateControl } from 'maplibre-gl';
+import { type FitBoundsOptions, GeolocateControl } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
 import { ControlComponent } from './control.component';
-import { Position } from '../map/map.types';
+import type { Position } from '../map/map.types';
 
 /**
  * `mglGeolocate` - a geolocate control directive
@@ -22,7 +22,7 @@ import { Position } from '../map/map.types';
   selector: '[mglGeolocate]',
   standalone: true,
 })
-export class GeolocateControlDirective implements AfterContentInit {
+export class GeolocateControlDirective {
   /* Init injection */
   private readonly mapService = inject(MapService);
   private readonly controlComponent = inject<
@@ -30,39 +30,41 @@ export class GeolocateControlDirective implements AfterContentInit {
   >(ControlComponent, { host: true });
 
   /* Init inputs */
-  @Input() positionOptions?: PositionOptions;
-  @Input() fitBoundsOptions?: FitBoundsOptions;
-  @Input() trackUserLocation?: boolean;
-  @Input() showUserLocation?: boolean;
+  readonly positionOptions = input<PositionOptions>();
+  readonly fitBoundsOptions = input<FitBoundsOptions>();
+  readonly trackUserLocation = input<boolean>();
+  readonly showUserLocation = input<boolean>();
 
   readonly geolocate = output<Position>();
 
-  ngAfterContentInit() {
-    this.mapService.mapCreated$.subscribe(() => {
-      if (this.controlComponent.control) {
-        throw new Error('Another control is already set for this control');
-      }
-      const options = {
-        positionOptions: this.positionOptions,
-        fitBoundsOptions: this.fitBoundsOptions,
-        trackUserLocation: this.trackUserLocation,
-        showUserLocation: this.showUserLocation,
-      };
-
-      Object.keys(options).forEach((key: string) => {
-        const tkey = <keyof typeof options>key;
-        if (options[tkey] === undefined) {
-          delete options[tkey];
+  constructor() {
+    afterNextRender(() => {
+      this.mapService.mapCreated$.subscribe(() => {
+        if (this.controlComponent.control) {
+          throw new Error('Another control is already set for this control');
         }
+        const options = {
+          positionOptions: this.positionOptions(),
+          fitBoundsOptions: this.fitBoundsOptions(),
+          trackUserLocation: this.trackUserLocation(),
+          showUserLocation: this.showUserLocation(),
+        };
+
+        Object.keys(options).forEach((key: string) => {
+          const tkey = <keyof typeof options>key;
+          if (options[tkey] === undefined) {
+            delete options[tkey];
+          }
+        });
+        this.controlComponent.control = new GeolocateControl(options);
+        this.controlComponent.control.on('geolocate', (data: Position) => {
+          this.geolocate.emit(data);
+        });
+        this.mapService.addControl(
+          this.controlComponent.control,
+          this.controlComponent.position()
+        );
       });
-      this.controlComponent.control = new GeolocateControl(options);
-      this.controlComponent.control.on('geolocate', (data: Position) => {
-        this.geolocate.emit(data);
-      });
-      this.mapService.addControl(
-        this.controlComponent.control,
-        this.controlComponent.position
-      );
     });
   }
 }

--- a/projects/ngx-maplibre-gl/src/lib/control/geolocate-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/geolocate-control.directive.ts
@@ -13,7 +13,7 @@ import {
 import { MapService } from '../map/map.service';
 import { ControlComponent } from './control.component';
 import type { Position } from '../map/map.types';
-import { keepAvailableObjectValues } from '../shared';
+import { keepAvailableObjectValues } from '../shared/utils/functions/object.fn';
 
 /**
  * `mglGeolocate` - a geolocate control directive
@@ -36,8 +36,11 @@ export class GeolocateControlDirective {
 
   /* Init inputs */
   readonly positionOptions = input<PositionOptions>();
+  /* Init inputs */
   readonly fitBoundsOptions = input<FitBoundsOptions>();
+  /* Init inputs */
   readonly trackUserLocation = input<boolean>();
+  /* Init inputs */
   readonly showUserLocation = input<boolean>();
 
   readonly geolocate = output<Position>();

--- a/projects/ngx-maplibre-gl/src/lib/control/geolocate-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/geolocate-control.directive.ts
@@ -5,10 +5,15 @@ import {
   input,
   output,
 } from '@angular/core';
-import { type FitBoundsOptions, GeolocateControl } from 'maplibre-gl';
+import {
+  type FitBoundsOptions,
+  GeolocateControl,
+  GeolocateControlOptions,
+} from 'maplibre-gl';
 import { MapService } from '../map/map.service';
 import { ControlComponent } from './control.component';
 import type { Position } from '../map/map.types';
+import { keepAvailableObjectValues } from '../shared';
 
 /**
  * `mglGeolocate` - a geolocate control directive
@@ -43,19 +48,14 @@ export class GeolocateControlDirective {
         if (this.controlComponent.control) {
           throw new Error('Another control is already set for this control');
         }
-        const options = {
+
+        const options = keepAvailableObjectValues<GeolocateControlOptions>({
           positionOptions: this.positionOptions(),
           fitBoundsOptions: this.fitBoundsOptions(),
           trackUserLocation: this.trackUserLocation(),
           showUserLocation: this.showUserLocation(),
-        };
-
-        Object.keys(options).forEach((key: string) => {
-          const tkey = <keyof typeof options>key;
-          if (options[tkey] === undefined) {
-            delete options[tkey];
-          }
         });
+
         this.controlComponent.control = new GeolocateControl(options);
         this.controlComponent.control.on('geolocate', (data: Position) => {
           this.geolocate.emit(data);

--- a/projects/ngx-maplibre-gl/src/lib/control/geolocate-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/geolocate-control.directive.ts
@@ -1,10 +1,9 @@
 import {
   AfterContentInit,
   Directive,
-  EventEmitter,
-  Host,
   Input,
-  Output,
+  inject,
+  output,
 } from '@angular/core';
 import { FitBoundsOptions, GeolocateControl } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
@@ -13,9 +12,9 @@ import { Position } from '../map/map.types';
 
 /**
  * `mglGeolocate` - a geolocate control directive
- * 
+ *
  * @category Directives
- * 
+ *
  * @see [Locate user](https://maplibre.org/ngx-maplibre-gl/demo/locate-user)
  * @see [GeolocateControl](https://maplibre.org/maplibre-gl-js/docs/API/classes/GeolocateControl)
  */
@@ -24,19 +23,19 @@ import { Position } from '../map/map.types';
   standalone: true,
 })
 export class GeolocateControlDirective implements AfterContentInit {
+  /* Init injection */
+  private readonly mapService = inject(MapService);
+  private readonly controlComponent = inject<
+    ControlComponent<GeolocateControl>
+  >(ControlComponent, { host: true });
+
   /* Init inputs */
   @Input() positionOptions?: PositionOptions;
   @Input() fitBoundsOptions?: FitBoundsOptions;
   @Input() trackUserLocation?: boolean;
   @Input() showUserLocation?: boolean;
 
-  @Output()
-  geolocate: EventEmitter<Position> = new EventEmitter<Position>();
-
-  constructor(
-    private mapService: MapService,
-    @Host() private controlComponent: ControlComponent<GeolocateControl>
-  ) {}
+  readonly geolocate = output<Position>();
 
   ngAfterContentInit() {
     this.mapService.mapCreated$.subscribe(() => {

--- a/projects/ngx-maplibre-gl/src/lib/control/navigation-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/navigation-control.directive.ts
@@ -1,4 +1,4 @@
-import { AfterContentInit, Directive, Input, inject } from '@angular/core';
+import { Directive, afterNextRender, inject, input } from '@angular/core';
 import { NavigationControl } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
 import { ControlComponent } from './control.component';
@@ -15,7 +15,7 @@ import { ControlComponent } from './control.component';
   selector: '[mglNavigation]',
   standalone: true,
 })
-export class NavigationControlDirective implements AfterContentInit {
+export class NavigationControlDirective {
   /* Init injection */
   private readonly mapService = inject(MapService);
   private readonly controlComponent = inject<
@@ -23,39 +23,42 @@ export class NavigationControlDirective implements AfterContentInit {
   >(ControlComponent, { host: true });
 
   /* Init inputs */
-  @Input() showCompass?: boolean;
-  @Input() showZoom?: boolean;
-  @Input() visualizePitch?: boolean;
+  readonly showCompass = input<boolean>();
+  readonly showZoom = input<boolean>();
+  readonly visualizePitch = input<boolean>();
 
-  ngAfterContentInit() {
-    this.mapService.mapCreated$.subscribe(() => {
-      if (this.controlComponent.control) {
-        throw new Error('Another control is already set for this control');
-      }
+  constructor() {
+    afterNextRender(() => {
+      this.mapService.mapCreated$.subscribe(() => {
+        if (this.controlComponent.control) {
+          throw new Error('Another control is already set for this control');
+        }
 
-      const options: {
-        showCompass?: boolean;
-        showZoom?: boolean;
-        visualizePitch?: boolean;
-      } = {};
+        const options: {
+          showCompass?: boolean;
+          showZoom?: boolean;
+          visualizePitch?: boolean;
+        } = {};
+        const showCompass = this.showCompass();
+        if (showCompass !== undefined) {
+          options.showCompass = showCompass;
+        }
+        const showZoom = this.showCompass();
+        if (showZoom !== undefined) {
+          options.showZoom = showZoom;
+        }
 
-      if (this.showCompass !== undefined) {
-        options.showCompass = this.showCompass;
-      }
+        const visualizePitch = this.visualizePitch();
+        if (this.visualizePitch !== undefined) {
+          options.visualizePitch = visualizePitch;
+        }
 
-      if (this.showZoom !== undefined) {
-        options.showZoom = this.showZoom;
-      }
-
-      if (this.visualizePitch != undefined) {
-        options.visualizePitch = this.visualizePitch;
-      }
-
-      this.controlComponent.control = new NavigationControl(options);
-      this.mapService.addControl(
-        this.controlComponent.control,
-        this.controlComponent.position
-      );
+        this.controlComponent.control = new NavigationControl(options);
+        this.mapService.addControl(
+          this.controlComponent.control,
+          this.controlComponent.position()
+        );
+      });
     });
   }
 }

--- a/projects/ngx-maplibre-gl/src/lib/control/navigation-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/navigation-control.directive.ts
@@ -1,13 +1,13 @@
-import { AfterContentInit, Directive, Host, Input } from '@angular/core';
+import { AfterContentInit, Directive, Input, inject } from '@angular/core';
 import { NavigationControl } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
 import { ControlComponent } from './control.component';
 
 /**
  * `mglNavigation` - a navigation control directive
- * 
+ *
  * @category Directives
- * 
+ *
  * @see [Navigation](https://maplibre.org/ngx-maplibre-gl/demo/navigation)
  * @see [NavigationControl](https://maplibre.org/maplibre-gl-js/docs/API/classes/NavigationControl)
  */
@@ -16,15 +16,16 @@ import { ControlComponent } from './control.component';
   standalone: true,
 })
 export class NavigationControlDirective implements AfterContentInit {
+  /* Init injection */
+  private readonly mapService = inject(MapService);
+  private readonly controlComponent = inject<
+    ControlComponent<NavigationControl>
+  >(ControlComponent, { host: true });
+
   /* Init inputs */
   @Input() showCompass?: boolean;
   @Input() showZoom?: boolean;
   @Input() visualizePitch?: boolean;
-
-  constructor(
-    private mapService: MapService,
-    @Host() private controlComponent: ControlComponent<NavigationControl>
-  ) {}
 
   ngAfterContentInit() {
     this.mapService.mapCreated$.subscribe(() => {

--- a/projects/ngx-maplibre-gl/src/lib/control/navigation-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/navigation-control.directive.ts
@@ -2,7 +2,7 @@ import { Directive, afterNextRender, inject, input } from '@angular/core';
 import { NavigationControl, type NavigationControlOptions } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
 import { ControlComponent } from './control.component';
-import { keepAvailableObjectValues } from '../shared';
+import { keepAvailableObjectValues } from '../shared/utils/functions/object.fn';
 
 /**
  * `mglNavigation` - a navigation control directive
@@ -25,7 +25,9 @@ export class NavigationControlDirective {
 
   /* Init inputs */
   readonly showCompass = input<boolean>();
+  /* Init inputs */
   readonly showZoom = input<boolean>();
+  /* Init inputs */
   readonly visualizePitch = input<boolean>();
 
   constructor() {

--- a/projects/ngx-maplibre-gl/src/lib/control/navigation-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/navigation-control.directive.ts
@@ -1,7 +1,8 @@
 import { Directive, afterNextRender, inject, input } from '@angular/core';
-import { NavigationControl } from 'maplibre-gl';
+import { NavigationControl, type NavigationControlOptions } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
 import { ControlComponent } from './control.component';
+import { keepAvailableObjectValues } from '../shared';
 
 /**
  * `mglNavigation` - a navigation control directive
@@ -33,26 +34,11 @@ export class NavigationControlDirective {
         if (this.controlComponent.control) {
           throw new Error('Another control is already set for this control');
         }
-
-        const options: {
-          showCompass?: boolean;
-          showZoom?: boolean;
-          visualizePitch?: boolean;
-        } = {};
-        const showCompass = this.showCompass();
-        if (showCompass !== undefined) {
-          options.showCompass = showCompass;
-        }
-        const showZoom = this.showCompass();
-        if (showZoom !== undefined) {
-          options.showZoom = showZoom;
-        }
-
-        const visualizePitch = this.visualizePitch();
-        if (this.visualizePitch !== undefined) {
-          options.visualizePitch = visualizePitch;
-        }
-
+        const options = keepAvailableObjectValues<NavigationControlOptions>({
+          showCompass: this.showCompass(),
+          showZoom: this.showZoom(),
+          visualizePitch: this.visualizePitch(),
+        });
         this.controlComponent.control = new NavigationControl(options);
         this.mapService.addControl(
           this.controlComponent.control,

--- a/projects/ngx-maplibre-gl/src/lib/control/scale-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/scale-control.directive.ts
@@ -9,7 +9,7 @@ import {
 import { ScaleControl, type Unit, type ScaleControlOptions } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
 import { ControlComponent } from './control.component';
-import { keepAvailableObjectValues } from '../shared/utils';
+import { keepAvailableObjectValues } from '../shared/utils/functions/object.fn';
 
 /**
  * `mglScale` - a scale control directive

--- a/projects/ngx-maplibre-gl/src/lib/control/scale-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/scale-control.directive.ts
@@ -9,6 +9,7 @@ import {
 import { ScaleControl, type Unit, type ScaleControlOptions } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
 import { ControlComponent } from './control.component';
+import { keepAvailableObjectValues } from '../shared/utils';
 
 /**
  * `mglScale` - a scale control directive
@@ -32,6 +33,8 @@ export class ScaleControlDirective implements OnChanges {
 
   /* Init inputs */
   readonly maxWidth = input<number>();
+
+  /* Dynamic inputs */
   readonly unit = input<Unit>();
 
   constructor() {
@@ -40,16 +43,11 @@ export class ScaleControlDirective implements OnChanges {
         if (this.controlComponent.control) {
           throw new Error('Another control is already set for this control');
         }
-        const options: ScaleControlOptions = {};
-        const maxWidth = this.maxWidth();
-        if (maxWidth !== undefined) {
-          options.maxWidth = maxWidth;
-        }
-        const unit = this.unit();
+        const options = keepAvailableObjectValues<ScaleControlOptions>({
+          maxWidth: this.maxWidth(),
+          unit: this.unit(),
+        });
 
-        if (unit !== undefined) {
-          options.unit = unit;
-        }
         this.controlComponent.control = new ScaleControl(options);
         this.mapService.addControl(
           this.controlComponent.control,

--- a/projects/ngx-maplibre-gl/src/lib/control/scale-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/scale-control.directive.ts
@@ -1,10 +1,10 @@
 import {
   AfterContentInit,
   Directive,
-  Host,
   Input,
   OnChanges,
   SimpleChanges,
+  inject,
 } from '@angular/core';
 import { ScaleControl, ScaleControlOptions } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
@@ -12,9 +12,9 @@ import { ControlComponent } from './control.component';
 
 /**
  * `mglScale` - a scale control directive
- * 
+ *
  * @category Directives
- * 
+ *
  * @see [Scale](https://maplibre.org/ngx-maplibre-gl/demo/ngx-scale-control)
  * @see [ScaleControl](https://maplibre.org/maplibre-gl-js/docs/API/classes/ScaleControl)
  */
@@ -23,16 +23,18 @@ import { ControlComponent } from './control.component';
   standalone: true,
 })
 export class ScaleControlDirective implements AfterContentInit, OnChanges {
+  /* Init injection */
+  private readonly mapService = inject(MapService);
+  private readonly controlComponent = inject<ControlComponent<ScaleControl>>(
+    ControlComponent,
+    { host: true }
+  );
+
   /* Init inputs */
   @Input() maxWidth?: number;
 
   /* Dynamic inputs */
   @Input() unit?: 'imperial' | 'metric' | 'nautical';
-
-  constructor(
-    private mapService: MapService,
-    @Host() private controlComponent: ControlComponent<ScaleControl>
-  ) {}
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes.unit && !changes.unit.isFirstChange()) {

--- a/projects/ngx-maplibre-gl/src/lib/control/scale-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/scale-control.directive.ts
@@ -6,7 +6,7 @@ import {
   inject,
   input,
 } from '@angular/core';
-import { ScaleControl,  type ScaleControlOptions } from 'maplibre-gl';
+import { ScaleControl, type Unit, type ScaleControlOptions } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
 import { ControlComponent } from './control.component';
 
@@ -32,9 +32,7 @@ export class ScaleControlDirective implements OnChanges {
 
   /* Init inputs */
   readonly maxWidth = input<number>();
-
-  /* Dynamic inputs */
-  readonly unit = input<'imperial' | 'metric' | 'nautical'>();
+  readonly unit = input<Unit>();
 
   constructor() {
     afterNextRender(() => {

--- a/projects/ngx-maplibre-gl/src/lib/control/terrain-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/terrain-control.directive.ts
@@ -1,13 +1,18 @@
-import { AfterContentInit, Directive, Host, Input } from '@angular/core';
+import {
+  AfterContentInit,
+  Directive,
+  Input,
+  inject,
+} from '@angular/core';
 import { TerrainControl, TerrainSpecification } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
 import { ControlComponent } from './control.component';
 
 /**
  * `mglTerrain` - a terrain control directive
- * 
+ *
  * @category Directives
- * 
+ *
  * @see [Terrain](https://maplibre.org/ngx-maplibre-gl/demo/terrain-control)
  * @see [TerrainControl](https://maplibre.org/maplibre-gl-js/docs/API/classes/TerrainControl)
  */
@@ -16,14 +21,16 @@ import { ControlComponent } from './control.component';
   standalone: true,
 })
 export class TerrainControlDirective implements AfterContentInit {
+  /* Init injection */
+  private readonly mapService = inject(MapService);
+  private readonly controlComponent = inject<ControlComponent<TerrainControl>>(
+    ControlComponent,
+    { host: true }
+  );
+
   /* Init inputs */
   @Input() source: string;
   @Input() exaggeration?: number;
-
-  constructor(
-    private mapService: MapService,
-    @Host() private controlComponent: ControlComponent<TerrainControl>
-  ) {}
 
   ngAfterContentInit() {
     this.mapService.mapCreated$.subscribe(() => {

--- a/projects/ngx-maplibre-gl/src/lib/control/terrain-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/terrain-control.directive.ts
@@ -1,10 +1,5 @@
-import {
-  AfterContentInit,
-  Directive,
-  Input,
-  inject,
-} from '@angular/core';
-import { TerrainControl, TerrainSpecification } from 'maplibre-gl';
+import { Directive, afterNextRender, inject, input } from '@angular/core';
+import { TerrainControl, type TerrainSpecification } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
 import { ControlComponent } from './control.component';
 
@@ -20,7 +15,7 @@ import { ControlComponent } from './control.component';
   selector: '[mglTerrain]',
   standalone: true,
 })
-export class TerrainControlDirective implements AfterContentInit {
+export class TerrainControlDirective {
   /* Init injection */
   private readonly mapService = inject(MapService);
   private readonly controlComponent = inject<ControlComponent<TerrainControl>>(
@@ -29,26 +24,28 @@ export class TerrainControlDirective implements AfterContentInit {
   );
 
   /* Init inputs */
-  @Input() source: string;
-  @Input() exaggeration?: number;
+  readonly source = input.required<string>();
+  readonly exaggeration = input<number>();
 
-  ngAfterContentInit() {
-    this.mapService.mapCreated$.subscribe(() => {
-      if (this.controlComponent.control) {
-        throw new Error('Another control is already set for this control');
-      }
+  constructor() {
+    afterNextRender(() => {
+      this.mapService.mapCreated$.subscribe(() => {
+        if (this.controlComponent.control) {
+          throw new Error('Another control is already set for this control');
+        }
 
-      const options: TerrainSpecification = {
-        source: this.source,
-        exaggeration: this.exaggeration ?? 1,
-      };
+        const options: TerrainSpecification = {
+          source: this.source(),
+          exaggeration: this.exaggeration() ?? 1,
+        };
 
-      this.controlComponent.control = new TerrainControl(options);
+        this.controlComponent.control = new TerrainControl(options);
 
-      this.mapService.addControl(
-        this.controlComponent.control,
-        this.controlComponent.position
-      );
+        this.mapService.addControl(
+          this.controlComponent.control,
+          this.controlComponent.position()
+        );
+      });
     });
   }
 }

--- a/projects/ngx-maplibre-gl/src/lib/image/image.component.spec.ts
+++ b/projects/ngx-maplibre-gl/src/lib/image/image.component.spec.ts
@@ -1,32 +1,31 @@
-import { SimpleChange } from '@angular/core';
+import { ComponentRef, SimpleChange } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { of } from 'rxjs';
 import { MapService } from '../map/map.service';
 import { ImageComponent } from './image.component';
 
 describe('ImageComponent', () => {
-  class MapServiceSpy {
-    addImage = jasmine.createSpy('addImage');
-    removeImage = jasmine.createSpy('removeImage');
-    mapLoaded$ = of(undefined);
-    mapInstance = new (class {
-      on() {}
-      off() {}
-      hasImage() {}
-    })();
-  }
-
-  let msSpy: MapServiceSpy;
+  let mapServiceStub: jasmine.SpyObj<MapService>;
   let component: ImageComponent;
+  let componentRef: ComponentRef<ImageComponent>;
   let fixture: ComponentFixture<ImageComponent>;
 
   beforeEach(waitForAsync(() => {
+    mapServiceStub = jasmine.createSpyObj(['addImage', 'removeImage'], {
+      mapLoaded$: of(true),
+      mapInstance: new (class {
+        on() {}
+        off() {}
+        hasImage() {}
+      })(),
+    });
+
     TestBed.configureTestingModule({
       imports: [ImageComponent],
     })
       .overrideComponent(ImageComponent, {
         set: {
-          providers: [{ provide: MapService, useClass: MapServiceSpy }],
+          providers: [{ provide: MapService, useValue: mapServiceStub }],
         },
       })
       .compileComponents();
@@ -35,52 +34,55 @@ describe('ImageComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ImageComponent);
     component = fixture.componentInstance;
-    msSpy = fixture.debugElement.injector.get<MapService>(MapService) as any;
-    component.id = 'imageId';
+    componentRef = fixture.componentRef;
   });
 
   describe('Init/Destroy tests', () => {
-    it('should init with custom inputs', () => {
-      component.data = {
+    beforeEach(() => {
+      componentRef.setInput('id', 'imageId');
+      componentRef.setInput('data', {
         width: 500,
         height: 500,
         data: new Uint8Array([5, 5]),
-      };
+      });
+
       fixture.detectChanges();
-      expect(msSpy.addImage).toHaveBeenCalled();
+    });
+
+    it('should init with custom inputs', () => {
+      expect(mapServiceStub.addImage).toHaveBeenCalled();
     });
 
     it('should remove image on destroy', () => {
-      component.data = {
-        width: 500,
-        height: 500,
-        data: new Uint8Array([5, 5]),
-      };
-      fixture.detectChanges();
       component.ngOnDestroy();
-      expect(msSpy.removeImage).toHaveBeenCalledWith(component.id);
-    });
-
-    it('should not remove image on destroy if not added', () => {
-      component.ngOnDestroy();
-      expect(msSpy.removeImage).not.toHaveBeenCalled();
+      expect(mapServiceStub.removeImage).toHaveBeenCalledWith('imageId');
     });
   });
 
+  it('should not remove image on destroy if not added', () => {
+    component.ngOnDestroy();
+    expect(mapServiceStub.removeImage).not.toHaveBeenCalled();
+  });
+
   describe('Change tests', () => {
-    it('should update image', () => {
-      component.id = 'layerId';
-      component.data = {
+    beforeEach(() => {
+      componentRef.setInput('id', 'layerId');
+      componentRef.setInput('data', {
         width: 500,
         height: 500,
         data: new Uint8Array([5, 5]),
-      };
-      fixture.detectChanges();
-      component.ngOnChanges({
-        data: new SimpleChange(null, component.data, false),
       });
-      expect(msSpy.removeImage).toHaveBeenCalledWith(component.id);
-      expect(msSpy.addImage).toHaveBeenCalled();
+
+      fixture.detectChanges();
+    });
+
+
+    it('should update image', () => {
+      component.ngOnChanges({
+        data: new SimpleChange(null, component.data(), false),
+      });
+      expect(mapServiceStub.removeImage).toHaveBeenCalledWith(component.id());
+      expect(mapServiceStub.addImage).toHaveBeenCalled();
     });
   });
 });

--- a/projects/ngx-maplibre-gl/src/lib/image/image.component.spec.ts
+++ b/projects/ngx-maplibre-gl/src/lib/image/image.component.spec.ts
@@ -54,13 +54,13 @@ describe('ImageComponent', () => {
     });
 
     it('should remove image on destroy', () => {
-      component.ngOnDestroy();
+      component.removeImage();
       expect(mapServiceStub.removeImage).toHaveBeenCalledWith('imageId');
     });
   });
 
   it('should not remove image on destroy if not added', () => {
-    component.ngOnDestroy();
+    component.removeImage();
     expect(mapServiceStub.removeImage).not.toHaveBeenCalled();
   });
 

--- a/projects/ngx-maplibre-gl/src/lib/image/image.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/image/image.component.ts
@@ -1,13 +1,13 @@
 import {
   Component,
-  EventEmitter,
   Input,
   NgZone,
   OnChanges,
   OnDestroy,
   OnInit,
-  Output,
   SimpleChanges,
+  inject,
+  output,
 } from '@angular/core';
 import { fromEvent, Subscription } from 'rxjs';
 import { filter, startWith, switchMap } from 'rxjs/operators';
@@ -17,9 +17,9 @@ import { MapImageData, MapImageOptions } from '../map/map.types';
 /**
  * `mgl-image` - an image component
  * @see [addImage](https://maplibre.org/maplibre-gl-js/docs/API/classes/Map/#addimage)
- * 
+ *
  * @category Components
- * 
+ *
  * @example
  * ```html
  * ...
@@ -51,6 +51,10 @@ import { MapImageData, MapImageOptions } from '../map/map.types';
   standalone: true,
 })
 export class ImageComponent implements OnInit, OnDestroy, OnChanges {
+  /** Init injection */
+  private readonly mapService = inject(MapService);
+  private readonly zone = inject(NgZone);
+
   /** Init input */
   @Input() id: string;
 
@@ -61,14 +65,14 @@ export class ImageComponent implements OnInit, OnDestroy, OnChanges {
   /** Dynamic input */
   @Input() url?: string;
 
-  @Output() imageError = new EventEmitter<{ status: number }>();
-  @Output() imageLoaded = new EventEmitter<void>();
+  imageError = output<{
+    status: number;
+  }>();
+  imageLoaded = output<void>();
 
   private isAdded = false;
   private isAdding = false;
   private sub: Subscription;
-
-  constructor(private mapService: MapService, private zone: NgZone) {}
 
   ngOnInit() {
     this.sub = this.mapService.mapLoaded$

--- a/projects/ngx-maplibre-gl/src/lib/image/image.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/image/image.component.ts
@@ -63,8 +63,11 @@ export class ImageComponent implements OnInit, OnChanges {
   /** Init input */
   readonly id = input.required<string>();
 
+  /** Dynamic input */
   readonly data = input<MapImageData>();
+  /** Dynamic input */
   readonly options = input<MapImageOptions>();
+  /** Dynamic input */
   readonly url = input<string>();
 
   readonly imageError = output<{
@@ -95,7 +98,7 @@ export class ImageComponent implements OnInit, OnChanges {
         ),
         takeUntilDestroyed(this.destroyRef)
       )
-      .subscribe(() => this.init());
+      .subscribe(() => this.addImage());
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -115,7 +118,7 @@ export class ImageComponent implements OnInit, OnChanges {
     }
   }
 
-  private async init() {
+  private async addImage() {
     this.isAdding.set(true);
     const data = this.data();
     const url = this.url();

--- a/projects/ngx-maplibre-gl/src/lib/image/image.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/image/image.component.ts
@@ -4,7 +4,6 @@ import {
   DestroyRef,
   NgZone,
   OnChanges,
-  OnDestroy,
   OnInit,
   SimpleChanges,
   inject,
@@ -55,7 +54,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ImageComponent implements OnInit, OnDestroy, OnChanges {
+export class ImageComponent implements OnInit, OnChanges {
   /** Init injection */
   private readonly mapService = inject(MapService);
   private readonly destroyRef = inject(DestroyRef);
@@ -64,7 +63,6 @@ export class ImageComponent implements OnInit, OnDestroy, OnChanges {
   /** Init input */
   readonly id = input.required<string>();
 
-  /** Dynamic input */
   readonly data = input<MapImageData>();
   readonly options = input<MapImageOptions>();
   readonly url = input<string>();
@@ -77,6 +75,10 @@ export class ImageComponent implements OnInit, OnDestroy, OnChanges {
 
   private isAdded = signal(false);
   private isAdding = signal(false);
+
+  constructor() {
+    this.destroyRef.onDestroy(() => this.removeImage());
+  }
 
   ngOnInit() {
     this.mapService.mapLoaded$
@@ -102,12 +104,12 @@ export class ImageComponent implements OnInit, OnDestroy, OnChanges {
       (changes.options && !changes.options.isFirstChange()) ||
       (changes.url && !changes.url.isFirstChange())
     ) {
-      this.ngOnDestroy();
+      this.removeImage();
       this.ngOnInit();
     }
   }
 
-  ngOnDestroy() {
+  removeImage() {
     if (this.isAdded()) {
       this.mapService.removeImage(this.id());
     }

--- a/projects/ngx-maplibre-gl/src/lib/layer/layer.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/layer/layer.component.ts
@@ -72,7 +72,6 @@ export class LayerComponent
    */
   readonly removeSource = input<boolean>();
 
-  /** Dynamic input */
   readonly filter = input<FilterSpecification>();
   readonly layout = input<LayerSpecification['layout']>();
   readonly paint = input<LayerSpecification['paint']>();

--- a/projects/ngx-maplibre-gl/src/lib/layer/layer.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/layer/layer.component.ts
@@ -1,12 +1,12 @@
 import {
   Component,
-  EventEmitter,
   Input,
   OnChanges,
   OnDestroy,
   OnInit,
-  Output,
   SimpleChanges,
+  inject,
+  output,
 } from '@angular/core';
 import {
   LayerSpecification,
@@ -22,9 +22,9 @@ import { EventData, LayerEvents } from '../map/map.types';
 /**
  * `mgl-layer` - a layer component
  * @see [layers](https://maplibre.org/maplibre-style-spec/layers/)
- * 
+ *
  * @category Layer Component
- * 
+ *
  * @example
  * ```html
  * ...
@@ -47,7 +47,11 @@ import { EventData, LayerEvents } from '../map/map.types';
   standalone: true,
 })
 export class LayerComponent
-  implements OnInit, OnDestroy, OnChanges, LayerEvents {
+  implements OnInit, OnDestroy, OnChanges, LayerEvents
+{
+  /** Init injection */
+  private readonly mapService = inject(MapService);
+
   /** Init input */
   @Input() id: LayerSpecification['id'];
   /** Init input */
@@ -60,7 +64,7 @@ export class LayerComponent
   @Input() sourceLayer?: string;
   /**
    * A flag to enable removeSource clean up functionality
-   * 
+   *
    * Init input
    */
   @Input() removeSource?: boolean;
@@ -78,35 +82,23 @@ export class LayerComponent
   /** Dynamic input */
   @Input() maxzoom?: LayerSpecification['maxzoom'];
 
-  @Output() layerClick = new EventEmitter<MapLayerMouseEvent & EventData>();
-  @Output() layerDblClick = new EventEmitter<MapLayerMouseEvent & EventData>();
-  @Output() layerMouseDown = new EventEmitter<MapLayerMouseEvent & EventData>();
-  @Output() layerMouseUp = new EventEmitter<MapLayerMouseEvent & EventData>();
-  @Output() layerMouseEnter = new EventEmitter<
-    MapLayerMouseEvent & EventData
-  >();
-  @Output() layerMouseLeave = new EventEmitter<
-    MapLayerMouseEvent & EventData
-  >();
-  @Output() layerMouseMove = new EventEmitter<MapLayerMouseEvent & EventData>();
-  @Output() layerMouseOver = new EventEmitter<MapLayerMouseEvent & EventData>();
-  @Output() layerMouseOut = new EventEmitter<MapLayerMouseEvent & EventData>();
-  @Output() layerContextMenu = new EventEmitter<
-    MapLayerMouseEvent & EventData
-  >();
-  @Output() layerTouchStart = new EventEmitter<
-    MapLayerTouchEvent & EventData
-  >();
-  @Output() layerTouchEnd = new EventEmitter<MapLayerTouchEvent & EventData>();
-  @Output() layerTouchCancel = new EventEmitter<
-    MapLayerTouchEvent & EventData
-  >();
+  readonly layerClick = output<MapLayerMouseEvent & EventData>();
+  readonly layerDblClick = output<MapLayerMouseEvent & EventData>();
+  readonly layerMouseDown = output<MapLayerMouseEvent & EventData>();
+  readonly layerMouseUp = output<MapLayerMouseEvent & EventData>();
+  readonly layerMouseEnter = output<MapLayerMouseEvent & EventData>();
+  readonly layerMouseLeave = output<MapLayerMouseEvent & EventData>();
+  readonly layerMouseMove = output<MapLayerMouseEvent & EventData>();
+  readonly layerMouseOver = output<MapLayerMouseEvent & EventData>();
+  readonly layerMouseOut = output<MapLayerMouseEvent & EventData>();
+  readonly layerContextMenu = output<MapLayerMouseEvent & EventData>();
+  readonly layerTouchStart = output<MapLayerTouchEvent & EventData>();
+  readonly layerTouchEnd = output<MapLayerTouchEvent & EventData>();
+  readonly layerTouchCancel = output<MapLayerTouchEvent & EventData>();
 
   private layerAdded = false;
   private sub: Subscription;
   private sourceIdAdded?: string;
-
-  constructor(private mapService: MapService) {}
 
   ngOnInit() {
     this.sub = this.mapService.mapLoaded$

--- a/projects/ngx-maplibre-gl/src/lib/map/map.component.spec.ts
+++ b/projects/ngx-maplibre-gl/src/lib/map/map.component.spec.ts
@@ -59,12 +59,6 @@ describe('MapComponent', () => {
   });
 
   describe('Init tests', () => {
-    // xit("should init", fakeAsync(() => {
-    //   tick();
-    //   fixture.detectChanges();
-    //   expect(mapServiceStub.setup.calls.count()).toBe(1);
-    // }));
-
     it('should init with custom inputs', () => {
       // Since we don't want to trigger afterNextRender, we need to create the component in a different way
       const componentRef = createComponent(MapComponent, {

--- a/projects/ngx-maplibre-gl/src/lib/map/map.component.spec.ts
+++ b/projects/ngx-maplibre-gl/src/lib/map/map.component.spec.ts
@@ -1,4 +1,10 @@
-import { ApplicationRef, createComponent, EnvironmentInjector, SimpleChange } from '@angular/core';
+import {
+  ApplicationRef,
+  ComponentRef,
+  EnvironmentInjector,
+  SimpleChange,
+  createComponent,
+} from '@angular/core';
 import {
   ComponentFixture,
   fakeAsync,
@@ -6,31 +12,39 @@ import {
   TestBed,
   waitForAsync,
 } from '@angular/core/testing';
-import { ReplaySubject } from 'rxjs';
+import { of } from 'rxjs';
 import { MapComponent } from './map.component';
 import { MapService } from './map.service';
 
-describe('MapComponent', () => {
-  class MapServiceSpy {
-    setup = jasmine.createSpy('setup');
-    updateMinZoom = jasmine.createSpy('updateMinZoom');
-    updateMaxPitch = jasmine.createSpy('updateMaxPitch');
-    updateMinPitch = jasmine.createSpy('updateMinPitch');
-    destroyMap = jasmine.createSpy('destroyMap');
-    mapCreated$ = new ReplaySubject(1);
-  }
+const getMapServiceStub = () =>
+  jasmine.createSpyObj(
+    [
+      'setup',
+      'updateMinZoom',
+      'updateMaxPitch',
+      'updateMinPitch',
+      'destroyMap',
+    ],
+    {
+      mapCreated$: of(true),
+    }
+  );
 
-  let msSpy: MapServiceSpy;
+describe('MapComponent', () => {
+  let mapServiceStub: jasmine.SpyObj<MapService>;
   let component: MapComponent;
+  let componentRef: ComponentRef<MapComponent>;
   let fixture: ComponentFixture<MapComponent>;
 
   beforeEach(waitForAsync(() => {
+    mapServiceStub = getMapServiceStub();
+
     TestBed.configureTestingModule({
       imports: [MapComponent],
     })
       .overrideComponent(MapComponent, {
         set: {
-          providers: [{ provide: MapService, useClass: MapServiceSpy }],
+          providers: [{ provide: MapService, useValue: mapServiceStub }],
         },
       })
       .compileComponents();
@@ -39,62 +53,67 @@ describe('MapComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(MapComponent);
     component = fixture.debugElement.componentInstance;
-    msSpy = fixture.debugElement.injector.get<MapService>(MapService) as any;
+    componentRef = fixture.componentRef;
+    componentRef.setInput('style', 'style');
+    fixture.detectChanges();
   });
 
   describe('Init tests', () => {
-    it('should init', () => {
-      fixture.detectChanges();
-      expect(msSpy.setup.calls.count()).toBe(1);
-    });
+    // xit("should init", fakeAsync(() => {
+    //   tick();
+    //   fixture.detectChanges();
+    //   expect(mapServiceStub.setup.calls.count()).toBe(1);
+    // }));
 
     it('should init with custom inputs', () => {
       // Since we don't want to trigger afterNextRender, we need to create the component in a different way
       const componentRef = createComponent(MapComponent, {
         environmentInjector: TestBed.inject(EnvironmentInjector),
       });
-      msSpy = componentRef.injector.get<MapService>(MapService) as any;
-      componentRef.instance.style = 'style';
+      componentRef.setInput('style', 'style');
       TestBed.inject(ApplicationRef).attachView(componentRef.hostView);
-      expect(msSpy.setup.calls.count()).toBe(0);
+      expect(mapServiceStub.setup.calls.count()).toBe(0);
       TestBed.inject(ApplicationRef).tick();
-      expect(msSpy.setup.calls.count()).toBe(1);
-      expect(msSpy.setup.calls.first().args[0].mapOptions.style).toEqual('style');
+      expect(mapServiceStub.setup.calls.count()).toBe(1);
+      expect(
+        mapServiceStub.setup.calls.first().args[0].mapOptions.style
+      ).toEqual('style');
     });
   });
 
   describe('Change tests', () => {
     it('should update minzoom', fakeAsync(() => {
-      msSpy.mapCreated$.next(undefined);
-      msSpy.mapCreated$.complete();
-      component.minZoom = 6;
+      componentRef.setInput('minZoom', 6);
+
+      fixture.detectChanges();
+
       component.ngOnChanges({
-        minZoom: new SimpleChange(null, component.minZoom, false),
+        minZoom: new SimpleChange(null, component.minZoom(), false),
       });
       flushMicrotasks();
-      expect(msSpy.updateMinZoom).toHaveBeenCalledWith(6);
+      expect(mapServiceStub.updateMinZoom).toHaveBeenCalledWith(6);
     }));
 
     it('should update minpitch', fakeAsync(() => {
-      msSpy.mapCreated$.next(undefined);
-      msSpy.mapCreated$.complete();
-      component.minPitch = 15;
+      componentRef.setInput('minPitch', 15);
+      fixture.detectChanges();
+
       component.ngOnChanges({
-        minPitch: new SimpleChange(null, component.minPitch, false),
+        minPitch: new SimpleChange(null, component.minPitch(), false),
       });
       flushMicrotasks();
-      expect(msSpy.updateMinPitch).toHaveBeenCalledWith(15);
+      expect(mapServiceStub.updateMinPitch).toHaveBeenCalledWith(15);
     }));
 
     it('should update maxpitch', fakeAsync(() => {
-      msSpy.mapCreated$.next(undefined);
-      msSpy.mapCreated$.complete();
-      component.maxPitch = 25;
+      componentRef.setInput('maxPitch', 25);
+      fixture.detectChanges();
+
       component.ngOnChanges({
-        maxPitch: new SimpleChange(null, component.maxPitch, false),
+        maxPitch: new SimpleChange(null, component.maxPitch(), false),
       });
       flushMicrotasks();
-      expect(msSpy.updateMaxPitch).toHaveBeenCalledWith(25);
+      expect(mapServiceStub.updateMaxPitch).toHaveBeenCalledWith(25);
     }));
   });
 });

--- a/projects/ngx-maplibre-gl/src/lib/map/map.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/map/map.component.ts
@@ -2,14 +2,15 @@ import {
   ChangeDetectionStrategy,
   Component,
   ElementRef,
-  EventEmitter,
   Input,
   OnChanges,
   OnDestroy,
-  Output,
+  OutputRefSubscription,
   SimpleChanges,
-  ViewChild,
   afterNextRender,
+  inject,
+  output,
+  viewChild,
 } from '@angular/core';
 import {
   AnimationOptions,
@@ -30,7 +31,7 @@ import {
 } from 'maplibre-gl';
 import { MapService, MovingOptions } from './map.service';
 import { MapEvent, EventData } from './map.types';
-import { Subscription, firstValueFrom } from 'rxjs';
+import { firstValueFrom } from 'rxjs';
 
 /**
  * `mgl-map` - The main map component
@@ -84,6 +85,10 @@ export class MapComponent
     Omit<MapOptions, 'bearing' | 'container' | 'pitch' | 'zoom'>,
     MapEvent
 {
+  /** Init injection */
+  private readonly mapService = inject(MapService);
+  private readonly elementRef = inject(ElementRef);
+
   /** Init input */
   @Input() collectResourceTiming?: MapOptions['collectResourceTiming'];
   /** Init input */
@@ -185,98 +190,96 @@ export class MapComponent
   @Input() panToOptions?: AnimationOptions;
   @Input() cursorStyle?: string;
 
-  @Output() mapResize = new EventEmitter<MapLibreEvent & EventData>();
-  @Output() mapRemove = new EventEmitter<MapLibreEvent & EventData>();
-  @Output() mapMouseDown = new EventEmitter<MapMouseEvent & EventData>();
-  @Output() mapMouseUp = new EventEmitter<MapMouseEvent & EventData>();
-  @Output() mapMouseMove = new EventEmitter<MapMouseEvent & EventData>();
-  @Output() mapClick = new EventEmitter<MapMouseEvent & EventData>();
-  @Output() mapDblClick = new EventEmitter<MapMouseEvent & EventData>();
-  @Output() mapMouseOver = new EventEmitter<MapMouseEvent & EventData>();
-  @Output() mapMouseOut = new EventEmitter<MapMouseEvent & EventData>();
-  @Output() mapContextMenu = new EventEmitter<MapMouseEvent & EventData>();
-  @Output() mapTouchStart = new EventEmitter<MapTouchEvent & EventData>();
-  @Output() mapTouchEnd = new EventEmitter<MapTouchEvent & EventData>();
-  @Output() mapTouchMove = new EventEmitter<MapTouchEvent & EventData>();
-  @Output() mapTouchCancel = new EventEmitter<MapTouchEvent & EventData>();
-  @Output() mapWheel = new EventEmitter<MapWheelEvent & EventData>();
-  @Output() moveStart = new EventEmitter<
+  readonly mapResize = output<MapLibreEvent & EventData>();
+  readonly mapRemove = output<MapLibreEvent & EventData>();
+  readonly mapMouseDown = output<MapMouseEvent & EventData>();
+  readonly mapMouseUp = output<MapMouseEvent & EventData>();
+  readonly mapMouseMove = output<MapMouseEvent & EventData>();
+  readonly mapClick = output<MapMouseEvent & EventData>();
+  readonly mapDblClick = output<MapMouseEvent & EventData>();
+  readonly mapMouseOver = output<MapMouseEvent & EventData>();
+  readonly mapMouseOut = output<MapMouseEvent & EventData>();
+  readonly mapContextMenu = output<MapMouseEvent & EventData>();
+  readonly mapTouchStart = output<MapTouchEvent & EventData>();
+  readonly mapTouchEnd = output<MapTouchEvent & EventData>();
+  readonly mapTouchMove = output<MapTouchEvent & EventData>();
+  readonly mapTouchCancel = output<MapTouchEvent & EventData>();
+  readonly mapWheel = output<MapWheelEvent & EventData>();
+  readonly moveStart = output<
     MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined> & EventData
   >();
-  @Output() move = new EventEmitter<
+  readonly move = output<
     MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined> & EventData
   >();
-  @Output() moveEnd = new EventEmitter<
+  readonly moveEnd = output<
     MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined> & EventData
   >();
-  @Output() mapDragStart = new EventEmitter<
+  readonly mapDragStart = output<
     MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
   >();
-  @Output() mapDrag = new EventEmitter<
+  readonly mapDrag = output<
     MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
   >();
-  @Output() mapDragEnd = new EventEmitter<
+  readonly mapDragEnd = output<
     MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
   >();
-  @Output() zoomStart = new EventEmitter<
+  readonly zoomStart = output<
     MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined> & EventData
   >();
-  @Output() zoomEvt = new EventEmitter<
+  readonly zoomEvt = output<
     MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined> & EventData
   >();
-  @Output() zoomEnd = new EventEmitter<
+  readonly zoomEnd = output<
     MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined> & EventData
   >();
-  @Output() rotateStart = new EventEmitter<
+  readonly rotateStart = output<
     MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
   >();
-  @Output() rotate = new EventEmitter<
+  readonly rotate = output<
     MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
   >();
-  @Output() rotateEnd = new EventEmitter<
+  readonly rotateEnd = output<
     MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
   >();
-  @Output() pitchStart = new EventEmitter<
+  readonly pitchStart = output<
     MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
   >();
-  @Output() pitchEvt = new EventEmitter<
+  readonly pitchEvt = output<
     MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
   >();
-  @Output() pitchEnd = new EventEmitter<
+  readonly pitchEnd = output<
     MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
   >();
-  @Output() boxZoomStart = new EventEmitter<MapLibreZoomEvent & EventData>();
-  @Output() boxZoomEnd = new EventEmitter<MapLibreZoomEvent & EventData>();
-  @Output() boxZoomCancel = new EventEmitter<MapLibreZoomEvent & EventData>();
-  @Output() webGlContextLost = new EventEmitter<MapContextEvent & EventData>();
-  @Output() webGlContextRestored = new EventEmitter<
-    MapContextEvent & EventData
+  readonly boxZoomStart = output<MapLibreZoomEvent & EventData>();
+  readonly boxZoomEnd = output<MapLibreZoomEvent & EventData>();
+  readonly boxZoomCancel = output<MapLibreZoomEvent & EventData>();
+  readonly webGlContextLost = output<MapContextEvent & EventData>();
+  readonly webGlContextRestored = output<MapContextEvent & EventData>();
+  readonly mapLoad = output<Map>();
+  readonly idle = output<MapLibreEvent & EventData>();
+  readonly render = output<MapLibreEvent & EventData>();
+  readonly mapError = output<ErrorEvent & EventData>();
+  readonly data = output<MapDataEvent & EventData>();
+  readonly styleData = output<MapStyleDataEvent & EventData>();
+  readonly sourceData = output<MapSourceDataEvent & EventData>();
+  readonly dataLoading = output<MapDataEvent & EventData>();
+  readonly styleDataLoading = output<MapStyleDataEvent & EventData>();
+  readonly sourceDataLoading = output<MapSourceDataEvent & EventData>();
+  readonly styleImageMissing = output<
+    {
+      id: string;
+    } & EventData
   >();
-  @Output() mapLoad = new EventEmitter<Map>();
-  @Output() idle = new EventEmitter<MapLibreEvent & EventData>();
-  @Output() render = new EventEmitter<MapLibreEvent & EventData>();
-  @Output() mapError = new EventEmitter<ErrorEvent & EventData>();
-  @Output() data = new EventEmitter<MapDataEvent & EventData>();
-  @Output() styleData = new EventEmitter<MapStyleDataEvent & EventData>();
-  @Output() sourceData = new EventEmitter<MapSourceDataEvent & EventData>();
-  @Output() dataLoading = new EventEmitter<MapDataEvent & EventData>();
-  @Output() styleDataLoading = new EventEmitter<
-    MapStyleDataEvent & EventData
-  >();
-  @Output() sourceDataLoading = new EventEmitter<
-    MapSourceDataEvent & EventData
-  >();
-  @Output() styleImageMissing = new EventEmitter<{ id: string } & EventData>();
 
   get mapInstance(): Map {
     return this.mapService.mapInstance;
   }
 
-  private subscriptions: Subscription[] = [];
+  private subscriptions: OutputRefSubscription[] = [];
 
-  @ViewChild('container', { static: true }) mapContainer: ElementRef;
+  readonly mapContainer = viewChild.required<ElementRef>('container');
 
-  constructor(private mapService: MapService, private elementRef: ElementRef) {
+  constructor() {
     afterNextRender(() => {
       if (this.preserveDrawingBuffer) {
         // This is to allow better interaction with the map state
@@ -302,7 +305,7 @@ export class MapComponent
       this.mapService.setup({
         mapOptions: {
           collectResourceTiming: this.collectResourceTiming,
-          container: this.mapContainer.nativeElement,
+          container: this.mapContainer().nativeElement,
           crossSourceCollisions: this.crossSourceCollisions,
           fadeDuration: this.fadeDuration,
           minZoom: this.minZoom,

--- a/projects/ngx-maplibre-gl/src/lib/map/map.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/map/map.component.ts
@@ -2,17 +2,16 @@ import {
   ChangeDetectionStrategy,
   Component,
   ElementRef,
-  Input,
   OnChanges,
   OnDestroy,
-  OutputRefSubscription,
   SimpleChanges,
   afterNextRender,
   inject,
+  input,
   output,
   viewChild,
 } from '@angular/core';
-import {
+import type {
   AnimationOptions,
   LngLatBoundsLike,
   Map,
@@ -29,8 +28,8 @@ import {
   PointLike,
   TerrainSpecification,
 } from 'maplibre-gl';
-import { MapService, MovingOptions } from './map.service';
-import { MapEvent, EventData } from './map.types';
+import { MapService, type MovingOptions } from './map.service';
+import type { MapEvent, EventData } from './map.types';
 import { firstValueFrom } from 'rxjs';
 
 /**
@@ -78,117 +77,73 @@ import { firstValueFrom } from 'rxjs';
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
 })
-export class MapComponent
-  implements
-    OnChanges,
-    OnDestroy,
-    Omit<MapOptions, 'bearing' | 'container' | 'pitch' | 'zoom'>,
-    MapEvent
-{
+// Omit<MapOptions, "bearing" | "container" | "pitch" | "zoom">,
+export class MapComponent implements OnChanges, OnDestroy, MapEvent {
   /** Init injection */
   private readonly mapService = inject(MapService);
   private readonly elementRef = inject(ElementRef);
 
   /** Init input */
-  @Input() collectResourceTiming?: MapOptions['collectResourceTiming'];
-  /** Init input */
-  @Input() crossSourceCollisions?: MapOptions['crossSourceCollisions'];
-  /** Init input */
-  @Input() customMapboxApiUrl?: string;
-  /** Init input */
-  @Input() fadeDuration?: MapOptions['fadeDuration'];
-  /** Init input */
-  @Input() hash?: MapOptions['hash'];
-  /** Init input */
-  @Input() refreshExpiredTiles?: MapOptions['refreshExpiredTiles'];
-  /** Init input */
-  @Input()
-  failIfMajorPerformanceCaveat?: MapOptions['failIfMajorPerformanceCaveat'];
-  /** Init input */
-  @Input() bearingSnap?: MapOptions['bearingSnap'];
-  /** Init input */
-  @Input() interactive?: MapOptions['interactive'];
-  /** Init input */
-  @Input() pitchWithRotate?: MapOptions['pitchWithRotate'];
-  /** Init input */
-  @Input() clickTolerance?: MapOptions['clickTolerance'];
-  /** Init input */
-  @Input() attributionControl?: MapOptions['attributionControl'];
-  /** Init input */
-  @Input() logoPosition?: MapOptions['logoPosition'];
-  /** Init input */
-  @Input() maxTileCacheSize?: MapOptions['maxTileCacheSize'];
-  /** Init input */
-  @Input() localIdeographFontFamily?: MapOptions['localIdeographFontFamily'];
-  /** Init input */
-  @Input() preserveDrawingBuffer?: MapOptions['preserveDrawingBuffer'];
-  /** Init input */
-  @Input() trackResize?: MapOptions['trackResize'];
-  /** Init input */
-  @Input() transformRequest?: MapOptions['transformRequest'];
-  /** Init input */
-  @Input() bounds?: MapOptions['bounds']; // Use fitBounds for dynamic input
-  /** Init input */
-  @Input() antialias?: MapOptions['antialias'];
-  /** Init input */
-  @Input() locale: MapOptions['locale'];
-  /** Init inputs */
-  @Input() cooperativeGestures?: MapOptions['cooperativeGestures'];
+
+  readonly collectResourceTiming = input<MapOptions['collectResourceTiming']>();
+  readonly crossSourceCollisions = input<MapOptions['crossSourceCollisions']>();
+  readonly customMapboxApiUrl = input<string>();
+  readonly fadeDuration = input<MapOptions['fadeDuration']>();
+  readonly hash = input<MapOptions['hash']>();
+  readonly refreshExpiredTiles = input<MapOptions['refreshExpiredTiles']>();
+  readonly failIfMajorPerformanceCaveat =
+    input<MapOptions['failIfMajorPerformanceCaveat']>();
+  readonly bearingSnap = input<MapOptions['bearingSnap']>();
+  readonly interactive = input<MapOptions['interactive']>();
+  readonly pitchWithRotate = input<MapOptions['pitchWithRotate']>();
+  readonly clickTolerance = input<MapOptions['clickTolerance']>();
+  readonly attributionControl = input<MapOptions['attributionControl']>();
+  readonly logoPosition = input<MapOptions['logoPosition']>();
+  readonly maxTileCacheSize = input<MapOptions['maxTileCacheSize']>();
+  readonly localIdeographFontFamily =
+    input<MapOptions['localIdeographFontFamily']>();
+  readonly preserveDrawingBuffer = input<MapOptions['preserveDrawingBuffer']>();
+  readonly trackResize = input<MapOptions['trackResize']>();
+  readonly transformRequest = input<MapOptions['transformRequest']>();
+  readonly bounds = input<MapOptions['bounds']>();
+  readonly antialias = input<MapOptions['antialias']>();
+  readonly locale = input<MapOptions['locale']>();
+  readonly cooperativeGestures = input<MapOptions['cooperativeGestures']>();
 
   /** Dynamic input */
-  @Input() minZoom?: MapOptions['minZoom'];
-  /** Dynamic input */
-  @Input() maxZoom?: MapOptions['maxZoom'];
-  /** Dynamic input */
-  @Input() minPitch?: MapOptions['minPitch'];
-  /** Dynamic input */
-  @Input() maxPitch?: MapOptions['maxPitch'];
-  /** Dynamic input */
-  @Input() scrollZoom?: MapOptions['scrollZoom'];
-  /** Dynamic input */
-  @Input() dragRotate?: MapOptions['dragRotate'];
-  /** Dynamic input */
-  @Input() touchPitch?: MapOptions['touchPitch'];
-  /** Dynamic input */
-  @Input() touchZoomRotate?: MapOptions['touchZoomRotate'];
-  /** Dynamic input */
-  @Input() doubleClickZoom?: MapOptions['doubleClickZoom'];
-  /** Dynamic input */
-  @Input() keyboard?: MapOptions['keyboard'];
-  /** Dynamic input */
-  @Input() dragPan?: MapOptions['dragPan'];
-  /** Dynamic input */
-  @Input() boxZoom?: MapOptions['boxZoom'];
-  /** Dynamic input */
-  @Input() style: MapOptions['style'];
-  /** Dynamic input */
-  @Input() center?: MapOptions['center'];
-  /** Dynamic input */
-  @Input() maxBounds?: MapOptions['maxBounds'];
-  /** Dynamic input */
-  @Input() zoom?: [number];
-  /** Dynamic input */
-  @Input() bearing?: [number];
-  /** Dynamic input */
-  @Input() pitch?: [number];
-  /** Dynamic input */
-  @Input() fitBoundsOptions?: MapOptions['fitBoundsOptions']; // First value goes to options.fitBoundsOptions. Subsequents changes are passed to fitBounds
-  /** Dynamic input */
-  @Input() renderWorldCopies?: MapOptions['renderWorldCopies'];
-  /** Dynamic input */
-  @Input() terrain: TerrainSpecification;
+  readonly minZoom = input<MapOptions['minZoom']>();
+  readonly maxZoom = input<MapOptions['maxZoom']>();
+  readonly minPitch = input<MapOptions['minPitch']>();
+  readonly maxPitch = input<MapOptions['maxPitch']>();
+  readonly scrollZoom = input<MapOptions['scrollZoom']>();
+  readonly dragRotate = input<MapOptions['dragRotate']>();
+  readonly touchPitch = input<MapOptions['touchPitch']>();
+  readonly touchZoomRotate = input<MapOptions['touchZoomRotate']>();
+  readonly doubleClickZoom = input<MapOptions['doubleClickZoom']>();
+  readonly keyboard = input<MapOptions['keyboard']>();
+  readonly dragPan = input<MapOptions['dragPan']>();
+  readonly boxZoom = input<MapOptions['boxZoom']>();
+  readonly style = input.required<MapOptions['style']>();
+  readonly center = input<MapOptions['center']>();
+  readonly maxBounds = input<MapOptions['maxBounds']>();
+  readonly zoom = input<[number]>();
+  readonly bearing = input<[number]>();
+  readonly pitch = input<[number]>();
+  readonly fitBoundsOptions = input<MapOptions['fitBoundsOptions']>(); // First value goes to options.fitBoundsOptions. Subsequents changes are passed to fitBounds
+  readonly renderWorldCopies = input<MapOptions['renderWorldCopies']>();
+
+  readonly terrain = input<TerrainSpecification>();
 
   /** Added by ngx-mapbox-gl */
-  @Input() movingMethod: 'jumpTo' | 'easeTo' | 'flyTo' = 'flyTo';
-  /** Added by ngx-mapbox-gl */
-  @Input() movingOptions?: MovingOptions;
+  readonly movingMethod = input<'jumpTo' | 'easeTo' | 'flyTo'>('flyTo');
+  readonly movingOptions = input<MovingOptions>();
 
   // => First value is a alias to bounds input (since mapbox 0.53.0). Subsequents changes are passed to fitBounds
-  @Input() fitBounds?: LngLatBoundsLike;
-  @Input() fitScreenCoordinates?: [PointLike, PointLike];
-  @Input() centerWithPanTo?: boolean;
-  @Input() panToOptions?: AnimationOptions;
-  @Input() cursorStyle?: string;
+  readonly fitBounds = input<LngLatBoundsLike>();
+  readonly fitScreenCoordinates = input<[PointLike, PointLike]>();
+  readonly centerWithPanTo = input<boolean>();
+  readonly panToOptions = input<AnimationOptions>();
+  readonly cursorStyle = input<string>();
 
   readonly mapResize = output<MapLibreEvent & EventData>();
   readonly mapRemove = output<MapLibreEvent & EventData>();
@@ -275,96 +230,90 @@ export class MapComponent
     return this.mapService.mapInstance;
   }
 
-  private subscriptions: OutputRefSubscription[] = [];
-
   readonly mapContainer = viewChild.required<ElementRef>('container');
 
   constructor() {
     afterNextRender(() => {
-      if (this.preserveDrawingBuffer) {
+      if (this.preserveDrawingBuffer()) {
         // This is to allow better interaction with the map state
         const htmlElement: HTMLElement = this.elementRef.nativeElement;
         htmlElement.setAttribute('data-cy', 'map');
-        this.subscriptions.push(
-          this.mapLoad.subscribe(() => {
-            htmlElement.setAttribute('data-loaded', 'true');
-          })
-        );
-        this.subscriptions.push(
-          this.idle.subscribe(() => {
-            htmlElement.setAttribute('data-idle', 'true');
-          })
-        );
-        this.subscriptions.push(
-          this.render.subscribe(() => {
-            htmlElement.removeAttribute('data-idle');
-          })
-        );
+        this.mapLoad.subscribe(() => {
+          htmlElement.setAttribute('data-loaded', 'true');
+        });
+        this.idle.subscribe(() => {
+          htmlElement.setAttribute('data-idle', 'true');
+        });
+        this.render.subscribe(() => {
+          htmlElement.removeAttribute('data-idle');
+        });
       }
-
       this.mapService.setup({
         mapOptions: {
-          collectResourceTiming: this.collectResourceTiming,
+          collectResourceTiming: this.collectResourceTiming(),
           container: this.mapContainer().nativeElement,
-          crossSourceCollisions: this.crossSourceCollisions,
-          fadeDuration: this.fadeDuration,
-          minZoom: this.minZoom,
-          maxZoom: this.maxZoom,
-          minPitch: this.minPitch,
-          maxPitch: this.maxPitch,
-          style: this.style,
-          hash: this.hash,
-          interactive: this.interactive,
-          bearingSnap: this.bearingSnap,
-          pitchWithRotate: this.pitchWithRotate,
-          clickTolerance: this.clickTolerance,
-          attributionControl: this.attributionControl,
-          logoPosition: this.logoPosition,
-          failIfMajorPerformanceCaveat: this.failIfMajorPerformanceCaveat,
-          preserveDrawingBuffer: this.preserveDrawingBuffer,
-          refreshExpiredTiles: this.refreshExpiredTiles,
-          maxBounds: this.maxBounds,
-          scrollZoom: this.scrollZoom,
-          boxZoom: this.boxZoom,
-          dragRotate: this.dragRotate,
-          dragPan: this.dragPan,
-          keyboard: this.keyboard,
-          doubleClickZoom: this.doubleClickZoom,
-          touchPitch: this.touchPitch,
-          touchZoomRotate: this.touchZoomRotate,
-          trackResize: this.trackResize,
-          center: this.center,
-          zoom: this.zoom,
-          bearing: this.bearing,
-          pitch: this.pitch,
-          renderWorldCopies: this.renderWorldCopies,
-          maxTileCacheSize: this.maxTileCacheSize,
-          localIdeographFontFamily: this.localIdeographFontFamily,
-          transformRequest: this.transformRequest,
-          bounds: this.bounds ? this.bounds : this.fitBounds,
-          fitBoundsOptions: this.fitBoundsOptions,
-          antialias: this.antialias,
+          crossSourceCollisions: this.crossSourceCollisions(),
+          fadeDuration: this.fadeDuration(),
+          minZoom: this.minZoom(),
+          maxZoom: this.maxZoom(),
+          minPitch: this.minPitch(),
+          maxPitch: this.maxPitch(),
+          style: this.style(),
+          hash: this.hash(),
+          interactive: this.interactive(),
+          bearingSnap: this.bearingSnap(),
+          pitchWithRotate: this.pitchWithRotate(),
+          clickTolerance: this.clickTolerance(),
+          attributionControl: this.attributionControl(),
+          logoPosition: this.logoPosition(),
+          failIfMajorPerformanceCaveat: this.failIfMajorPerformanceCaveat(),
+          preserveDrawingBuffer: this.preserveDrawingBuffer(),
+          refreshExpiredTiles: this.refreshExpiredTiles(),
+          maxBounds: this.maxBounds(),
+          scrollZoom: this.scrollZoom(),
+          boxZoom: this.boxZoom(),
+          dragRotate: this.dragRotate(),
+          dragPan: this.dragPan(),
+          keyboard: this.keyboard(),
+          doubleClickZoom: this.doubleClickZoom(),
+          touchPitch: this.touchPitch(),
+          touchZoomRotate: this.touchZoomRotate(),
+          trackResize: this.trackResize(),
+          center: this.center(),
+          zoom: this.zoom(),
+          bearing: this.bearing(),
+          pitch: this.pitch(),
+          renderWorldCopies: this.renderWorldCopies(),
+          maxTileCacheSize: this.maxTileCacheSize(),
+          localIdeographFontFamily: this.localIdeographFontFamily(),
+          transformRequest: this.transformRequest(),
+          bounds: this.bounds() ? this.bounds() : this.fitBounds(),
+          fitBoundsOptions: this.fitBoundsOptions(),
+          antialias: this.antialias(),
           locale: this.locale,
-          cooperativeGestures: this.cooperativeGestures,
-          terrain: this.terrain,
+          cooperativeGestures: this.cooperativeGestures(),
+          terrain: this.terrain(),
         },
         mapEvents: this,
       });
-      if (this.cursorStyle) {
-        this.mapService.changeCanvasCursor(this.cursorStyle);
+      const cursorStyle = this.cursorStyle();
+      if (cursorStyle) {
+        this.mapService.changeCanvasCursor(cursorStyle);
       }
     });
   }
 
   ngOnDestroy() {
     this.mapService.destroyMap();
-    for (const subscription of this.subscriptions) {
-      subscription.unsubscribe();
-    }
   }
 
   async ngOnChanges(changes: SimpleChanges) {
     await firstValueFrom(this.mapService.mapCreated$);
+    const zoom = this.zoom();
+    const bearing = this.bearing();
+    const pitch = this.pitch();
+    const center = this.center();
+
     if (changes.cursorStyle && !changes.cursorStyle.isFirstChange()) {
       this.mapService.changeCanvasCursor(changes.cursorStyle.currentValue);
     }
@@ -429,7 +378,7 @@ export class MapComponent
     ) {
       this.mapService.fitBounds(
         changes.fitBounds.currentValue,
-        this.fitBoundsOptions
+        this.fitBoundsOptions()
       );
     }
     if (
@@ -437,7 +386,7 @@ export class MapComponent
       changes.fitScreenCoordinates.currentValue
     ) {
       if (
-        (this.center || this.zoom || this.pitch || this.fitBounds) &&
+        (center || zoom || pitch || this.fitBounds()) &&
         changes.fitScreenCoordinates.isFirstChange()
       ) {
         console.warn(
@@ -446,19 +395,19 @@ export class MapComponent
       }
       this.mapService.fitScreenCoordinates(
         changes.fitScreenCoordinates.currentValue,
-        this.bearing ? this.bearing[0] : 0,
-        this.movingOptions
+        bearing ? bearing[0] : 0,
+        this.movingOptions()
       );
     }
     if (
-      this.centerWithPanTo &&
+      this.centerWithPanTo() &&
       changes.center &&
       !changes.center.isFirstChange() &&
       !changes.zoom &&
       !changes.bearing &&
       !changes.pitch
     ) {
-      this.mapService.panTo(this.center!, this.panToOptions);
+      this.mapService.panTo(this.center()!, this.panToOptions());
     } else if (
       (changes.center && !changes.center.isFirstChange()) ||
       (changes.zoom && !changes.zoom.isFirstChange()) ||
@@ -468,12 +417,12 @@ export class MapComponent
       (changes.pitch && !changes.pitch.isFirstChange())
     ) {
       this.mapService.move(
-        this.movingMethod,
-        this.movingOptions,
-        changes.zoom && this.zoom ? this.zoom[0] : undefined,
-        changes.center ? this.center : undefined,
-        changes.bearing && this.bearing ? this.bearing[0] : undefined,
-        changes.pitch && this.pitch ? this.pitch[0] : undefined
+        this.movingMethod(),
+        this.movingOptions(),
+        changes.zoom && zoom ? zoom[0] : undefined,
+        changes.center ? center : undefined,
+        changes.bearing && bearing ? bearing[0] : undefined,
+        changes.pitch && pitch ? pitch[0] : undefined
       );
     }
     if (changes.terrain && !changes.terrain.isFirstChange()) {

--- a/projects/ngx-maplibre-gl/src/lib/map/map.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/map/map.component.ts
@@ -77,14 +77,12 @@ import { firstValueFrom } from 'rxjs';
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
 })
-// Omit<MapOptions, "bearing" | "container" | "pitch" | "zoom">,
 export class MapComponent implements OnChanges, OnDestroy, MapEvent {
   /** Init injection */
   private readonly mapService = inject(MapService);
   private readonly elementRef = inject(ElementRef);
 
   /** Init input */
-
   readonly collectResourceTiming = input<MapOptions['collectResourceTiming']>();
   readonly crossSourceCollisions = input<MapOptions['crossSourceCollisions']>();
   readonly customMapboxApiUrl = input<string>();
@@ -110,7 +108,6 @@ export class MapComponent implements OnChanges, OnDestroy, MapEvent {
   readonly locale = input<MapOptions['locale']>();
   readonly cooperativeGestures = input<MapOptions['cooperativeGestures']>();
 
-  /** Dynamic input */
   readonly minZoom = input<MapOptions['minZoom']>();
   readonly maxZoom = input<MapOptions['maxZoom']>();
   readonly minPitch = input<MapOptions['minPitch']>();
@@ -230,7 +227,7 @@ export class MapComponent implements OnChanges, OnDestroy, MapEvent {
     return this.mapService.mapInstance;
   }
 
-  readonly mapContainer = viewChild.required<ElementRef>('container');
+  readonly mapContainer = viewChild.required<ElementRef<HTMLDivElement>>('container');
 
   constructor() {
     afterNextRender(() => {

--- a/projects/ngx-maplibre-gl/src/lib/map/map.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/map/map.component.ts
@@ -84,51 +84,92 @@ export class MapComponent implements OnChanges, OnDestroy, MapEvent {
 
   /** Init input */
   readonly collectResourceTiming = input<MapOptions['collectResourceTiming']>();
+  /** Init input */
   readonly crossSourceCollisions = input<MapOptions['crossSourceCollisions']>();
+  /** Init input */
   readonly customMapboxApiUrl = input<string>();
+  /** Init input */
   readonly fadeDuration = input<MapOptions['fadeDuration']>();
+  /** Init input */
   readonly hash = input<MapOptions['hash']>();
+  /** Init input */
   readonly refreshExpiredTiles = input<MapOptions['refreshExpiredTiles']>();
+  /** Init input */
   readonly failIfMajorPerformanceCaveat =
     input<MapOptions['failIfMajorPerformanceCaveat']>();
+  /** Init input */
   readonly bearingSnap = input<MapOptions['bearingSnap']>();
+  /** Init input */
   readonly interactive = input<MapOptions['interactive']>();
+  /** Init input */
   readonly pitchWithRotate = input<MapOptions['pitchWithRotate']>();
+  /** Init input */
   readonly clickTolerance = input<MapOptions['clickTolerance']>();
+  /** Init input */
   readonly attributionControl = input<MapOptions['attributionControl']>();
+  /** Init input */
   readonly logoPosition = input<MapOptions['logoPosition']>();
+  /** Init input */
   readonly maxTileCacheSize = input<MapOptions['maxTileCacheSize']>();
+  /** Init input */
   readonly localIdeographFontFamily =
     input<MapOptions['localIdeographFontFamily']>();
+  /** Init input */
   readonly preserveDrawingBuffer = input<MapOptions['preserveDrawingBuffer']>();
+  /** Init input */
   readonly trackResize = input<MapOptions['trackResize']>();
+  /** Init input */
   readonly transformRequest = input<MapOptions['transformRequest']>();
+  /** Init input */
   readonly bounds = input<MapOptions['bounds']>();
+  /** Init input */
   readonly antialias = input<MapOptions['antialias']>();
+  /** Init input */
   readonly locale = input<MapOptions['locale']>();
+  /** Init input */
   readonly cooperativeGestures = input<MapOptions['cooperativeGestures']>();
 
+  /** Dynamic input */
   readonly minZoom = input<MapOptions['minZoom']>();
+  /** Dynamic input */
   readonly maxZoom = input<MapOptions['maxZoom']>();
+  /** Dynamic input */
   readonly minPitch = input<MapOptions['minPitch']>();
+  /** Dynamic input */
   readonly maxPitch = input<MapOptions['maxPitch']>();
+  /** Dynamic input */
   readonly scrollZoom = input<MapOptions['scrollZoom']>();
+  /** Dynamic input */
   readonly dragRotate = input<MapOptions['dragRotate']>();
+  /** Dynamic input */
   readonly touchPitch = input<MapOptions['touchPitch']>();
+  /** Dynamic input */
   readonly touchZoomRotate = input<MapOptions['touchZoomRotate']>();
+  /** Dynamic input */
   readonly doubleClickZoom = input<MapOptions['doubleClickZoom']>();
+  /** Dynamic input */
   readonly keyboard = input<MapOptions['keyboard']>();
+  /** Dynamic input */
   readonly dragPan = input<MapOptions['dragPan']>();
+  /** Dynamic input */
   readonly boxZoom = input<MapOptions['boxZoom']>();
+  /** Dynamic input */
   readonly style = input.required<MapOptions['style']>();
+  /** Dynamic input */
   readonly center = input<MapOptions['center']>();
+  /** Dynamic input */
   readonly maxBounds = input<MapOptions['maxBounds']>();
+  /** Dynamic input */
   readonly zoom = input<[number]>();
+  /** Dynamic input */
   readonly bearing = input<[number]>();
+  /** Dynamic input */
   readonly pitch = input<[number]>();
+  /** Dynamic input */
   readonly fitBoundsOptions = input<MapOptions['fitBoundsOptions']>(); // First value goes to options.fitBoundsOptions. Subsequents changes are passed to fitBounds
+  /** Dynamic input */
   readonly renderWorldCopies = input<MapOptions['renderWorldCopies']>();
-
+  /** Dynamic input */
   readonly terrain = input<TerrainSpecification>();
 
   /** Added by ngx-mapbox-gl */

--- a/projects/ngx-maplibre-gl/src/lib/map/map.service.spec.ts
+++ b/projects/ngx-maplibre-gl/src/lib/map/map.service.spec.ts
@@ -201,12 +201,4 @@ describe('MapService', () => {
       done();
     });
   });
-
-  // xit('should update zoom', (done: DoneFn) => inject([MapService], (service: MapService) => {
-  //   mapEvents.mapEvents.load.first().subscribe(() => {
-  //     service.prepareZoom(6);
-  //     service.startMoveIfNeeded
-  //     done();
-  //   });
-  // })());
 });

--- a/projects/ngx-maplibre-gl/src/lib/map/map.service.spec.ts
+++ b/projects/ngx-maplibre-gl/src/lib/map/map.service.spec.ts
@@ -1,5 +1,5 @@
-import { EventEmitter, NgZone } from '@angular/core';
-import { inject, TestBed } from '@angular/core/testing';
+import { OutputEmitterRef, NgZone } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import {
   Map,
   MapLibreEvent,
@@ -13,7 +13,6 @@ import {
   MapWheelEvent,
   StyleSpecification,
 } from 'maplibre-gl';
-import { first } from 'rxjs/operators';
 import { MapService } from './map.service';
 import { MapEvent, EventData } from './map.types';
 import { MockNgZone } from './mock-ng-zone';
@@ -45,6 +44,7 @@ const geoJSONStyle: StyleSpecification = {
 describe('MapService', () => {
   let container: HTMLElement;
   let mapEvents: MapEvent;
+  let mapService: MapService;
   let zone: MockNgZone;
 
   beforeEach(() => {
@@ -61,94 +61,102 @@ describe('MapService', () => {
       ],
     });
     container = document.createElement('div');
-    mapEvents = {
-      mapResize: new EventEmitter<MapLibreEvent & EventData>(),
-      mapRemove: new EventEmitter<MapLibreEvent & EventData>(),
-      mapMouseDown: new EventEmitter<MapMouseEvent & EventData>(),
-      mapMouseUp: new EventEmitter<MapMouseEvent & EventData>(),
-      mapMouseMove: new EventEmitter<MapMouseEvent & EventData>(),
-      mapClick: new EventEmitter<MapMouseEvent & EventData>(),
-      mapDblClick: new EventEmitter<MapMouseEvent & EventData>(),
-      mapMouseOver: new EventEmitter<MapMouseEvent & EventData>(),
-      mapMouseOut: new EventEmitter<MapMouseEvent & EventData>(),
-      mapContextMenu: new EventEmitter<MapMouseEvent & EventData>(),
-      mapTouchStart: new EventEmitter<MapTouchEvent & EventData>(),
-      mapTouchEnd: new EventEmitter<MapTouchEvent & EventData>(),
-      mapTouchMove: new EventEmitter<MapTouchEvent & EventData>(),
-      mapTouchCancel: new EventEmitter<MapTouchEvent & EventData>(),
-      mapWheel: new EventEmitter<MapWheelEvent & EventData>(),
-      moveStart: new EventEmitter<
-        MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined> &
-          EventData
-      >(),
-      move: new EventEmitter<
-        MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined> &
-          EventData
-      >(),
-      moveEnd: new EventEmitter<
-        MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined> &
-          EventData
-      >(),
-      mapDragStart: new EventEmitter<
-        MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
-      >(),
-      mapDrag: new EventEmitter<
-        MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
-      >(),
-      mapDragEnd: new EventEmitter<
-        MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
-      >(),
-      zoomStart: new EventEmitter<
-        MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined> &
-          EventData
-      >(),
-      zoomEvt: new EventEmitter<
-        MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined> &
-          EventData
-      >(),
-      zoomEnd: new EventEmitter<
-        MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined> &
-          EventData
-      >(),
-      rotateStart: new EventEmitter<
-        MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
-      >(),
-      rotate: new EventEmitter<
-        MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
-      >(),
-      rotateEnd: new EventEmitter<
-        MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
-      >(),
-      pitchStart: new EventEmitter<
-        MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
-      >(),
-      pitchEvt: new EventEmitter<
-        MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
-      >(),
-      pitchEnd: new EventEmitter<
-        MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
-      >(),
-      boxZoomStart: new EventEmitter<MapLibreZoomEvent & EventData>(),
-      boxZoomEnd: new EventEmitter<MapLibreZoomEvent & EventData>(),
-      boxZoomCancel: new EventEmitter<MapLibreZoomEvent & EventData>(),
-      webGlContextLost: new EventEmitter<MapContextEvent & EventData>(),
-      webGlContextRestored: new EventEmitter<MapContextEvent & EventData>(),
-      mapLoad: new EventEmitter<Map>(),
-      render: new EventEmitter<MapLibreEvent & EventData>(),
-      mapError: new EventEmitter<ErrorEvent & EventData>(),
-      data: new EventEmitter<MapDataEvent & EventData>(),
-      styleData: new EventEmitter<MapStyleDataEvent & EventData>(),
-      sourceData: new EventEmitter<MapSourceDataEvent & EventData>(),
-      dataLoading: new EventEmitter<MapDataEvent & EventData>(),
-      styleDataLoading: new EventEmitter<MapStyleDataEvent & EventData>(),
-      sourceDataLoading: new EventEmitter<MapSourceDataEvent & EventData>(),
-      styleImageMissing: new EventEmitter<{ id: string } & EventData>(),
-      idle: new EventEmitter<MapLibreEvent & EventData>(),
-    };
+    mapService = TestBed.inject(MapService);
+
+    TestBed.runInInjectionContext(() => {
+      mapEvents = {
+        mapResize: new OutputEmitterRef<MapLibreEvent & EventData>(),
+        mapRemove: new OutputEmitterRef<MapLibreEvent & EventData>(),
+        mapMouseDown: new OutputEmitterRef<MapMouseEvent & EventData>(),
+        mapMouseUp: new OutputEmitterRef<MapMouseEvent & EventData>(),
+        mapMouseMove: new OutputEmitterRef<MapMouseEvent & EventData>(),
+        mapClick: new OutputEmitterRef<MapMouseEvent & EventData>(),
+        mapDblClick: new OutputEmitterRef<MapMouseEvent & EventData>(),
+        mapMouseOver: new OutputEmitterRef<MapMouseEvent & EventData>(),
+        mapMouseOut: new OutputEmitterRef<MapMouseEvent & EventData>(),
+        mapContextMenu: new OutputEmitterRef<MapMouseEvent & EventData>(),
+        mapTouchStart: new OutputEmitterRef<MapTouchEvent & EventData>(),
+        mapTouchEnd: new OutputEmitterRef<MapTouchEvent & EventData>(),
+        mapTouchMove: new OutputEmitterRef<MapTouchEvent & EventData>(),
+        mapTouchCancel: new OutputEmitterRef<MapTouchEvent & EventData>(),
+        mapWheel: new OutputEmitterRef<MapWheelEvent & EventData>(),
+        moveStart: new OutputEmitterRef<
+          MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined> &
+            EventData
+        >(),
+        move: new OutputEmitterRef<
+          MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined> &
+            EventData
+        >(),
+        moveEnd: new OutputEmitterRef<
+          MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined> &
+            EventData
+        >(),
+        mapDragStart: new OutputEmitterRef<
+          MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
+        >(),
+        mapDrag: new OutputEmitterRef<
+          MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
+        >(),
+        mapDragEnd: new OutputEmitterRef<
+          MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
+        >(),
+        zoomStart: new OutputEmitterRef<
+          MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined> &
+            EventData
+        >(),
+        zoomEvt: new OutputEmitterRef<
+          MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined> &
+            EventData
+        >(),
+        zoomEnd: new OutputEmitterRef<
+          MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined> &
+            EventData
+        >(),
+        rotateStart: new OutputEmitterRef<
+          MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
+        >(),
+        rotate: new OutputEmitterRef<
+          MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
+        >(),
+        rotateEnd: new OutputEmitterRef<
+          MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
+        >(),
+        pitchStart: new OutputEmitterRef<
+          MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
+        >(),
+        pitchEvt: new OutputEmitterRef<
+          MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
+        >(),
+        pitchEnd: new OutputEmitterRef<
+          MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
+        >(),
+        boxZoomStart: new OutputEmitterRef<MapLibreZoomEvent & EventData>(),
+        boxZoomEnd: new OutputEmitterRef<MapLibreZoomEvent & EventData>(),
+        boxZoomCancel: new OutputEmitterRef<MapLibreZoomEvent & EventData>(),
+        webGlContextLost: new OutputEmitterRef<MapContextEvent & EventData>(),
+        webGlContextRestored: new OutputEmitterRef<
+          MapContextEvent & EventData
+        >(),
+        mapLoad: new OutputEmitterRef<Map>(),
+        render: new OutputEmitterRef<MapLibreEvent & EventData>(),
+        mapError: new OutputEmitterRef<ErrorEvent & EventData>(),
+        data: new OutputEmitterRef<MapDataEvent & EventData>(),
+        styleData: new OutputEmitterRef<MapStyleDataEvent & EventData>(),
+        sourceData: new OutputEmitterRef<MapSourceDataEvent & EventData>(),
+        dataLoading: new OutputEmitterRef<MapDataEvent & EventData>(),
+        styleDataLoading: new OutputEmitterRef<MapStyleDataEvent & EventData>(),
+        sourceDataLoading: new OutputEmitterRef<
+          MapSourceDataEvent & EventData
+        >(),
+        styleImageMissing: new OutputEmitterRef<{ id: string } & EventData>(),
+        idle: new OutputEmitterRef<MapLibreEvent & EventData>(),
+      };
+    });
   });
 
-  beforeEach(inject([MapService], (service: MapService) => {
-    service.setup({
+  beforeEach(() => {
+    mapService.setup({
       mapOptions: {
         container,
         style: geoJSONStyle,
@@ -157,45 +165,42 @@ describe('MapService', () => {
       mapEvents,
     });
     zone.simulateZoneExit();
-  }));
+  });
 
-  it('should create a map', inject([MapService], (service: MapService) => {
-    expect(service.mapInstance).toBeTruthy();
-  }));
+  it('should create a map', () => {
+    expect(mapService.mapInstance).toBeTruthy();
+  });
 
   it('should fire mapLoad event', (done: DoneFn) => {
-    mapEvents.mapLoad.pipe(first()).subscribe(() => {
+    mapEvents.mapLoad.subscribe(() => {
       expect(true).toBe(true);
       done();
     });
   });
 
-  it('should update minZoom', (done: DoneFn) =>
-    inject([MapService], (service: MapService) => {
-      mapEvents.mapLoad.pipe(first()).subscribe(() => {
-        service.updateMinZoom(6);
-        expect(service.mapInstance.getMinZoom()).toEqual(6);
-        done();
-      });
-    })());
+  it('should update minZoom', (done: DoneFn) => {
+    mapEvents.mapLoad.subscribe(() => {
+      mapService.updateMinZoom(6);
+      expect(mapService.mapInstance.getMinZoom()).toEqual(6);
+      done();
+    });
+  });
 
-  it('should update minPitch', (done: DoneFn) =>
-    inject([MapService], (service: MapService) => {
-      mapEvents.mapLoad.pipe(first()).subscribe(() => {
-        service.updateMinPitch(15);
-        expect(service.mapInstance.getMinPitch()).toEqual(15);
-        done();
-      });
-    })());
+  it('should update minPitch', (done: DoneFn) => {
+    mapEvents.mapLoad.subscribe(() => {
+      mapService.updateMinPitch(15);
+      expect(mapService.mapInstance.getMinPitch()).toEqual(15);
+      done();
+    });
+  });
 
-  it('should update maxPitch', (done: DoneFn) =>
-    inject([MapService], (service: MapService) => {
-      mapEvents.mapLoad.pipe(first()).subscribe(() => {
-        service.updateMaxPitch(25);
-        expect(service.mapInstance.getMaxPitch()).toEqual(25);
-        done();
-      });
-    })());
+  it('should update maxPitch', (done: DoneFn) => {
+    mapEvents.mapLoad.subscribe(() => {
+      mapService.updateMaxPitch(25);
+      expect(mapService.mapInstance.getMaxPitch()).toEqual(25);
+      done();
+    });
+  });
 
   // xit('should update zoom', (done: DoneFn) => inject([MapService], (service: MapService) => {
   //   mapEvents.mapEvents.load.first().subscribe(() => {

--- a/projects/ngx-maplibre-gl/src/lib/map/map.service.ts
+++ b/projects/ngx-maplibre-gl/src/lib/map/map.service.ts
@@ -1,37 +1,43 @@
-import { Injectable, NgZone, OutputEmitterRef, inject } from '@angular/core';
 import {
-  CameraOptions,
-  FlyToOptions,
-  LngLatLike,
-  MapOptions,
-  MarkerOptions,
-  PopupOptions,
+  Injectable,
+  NgZone,
+  OutputEmitterRef,
+  inject,
+  signal,
+} from '@angular/core';
+import {
+  type CameraOptions,
+  type FlyToOptions,
+  type LngLatLike,
+  type MapOptions,
+  type MarkerOptions,
+  type PopupOptions,
   Map,
   Marker,
   Popup,
-  AnimationOptions,
-  LayerSpecification,
-  StyleSpecification,
-  LngLatBoundsLike,
-  PointLike,
-  IControl,
-  SourceSpecification,
-  FitBoundsOptions,
-  Source,
-  BackgroundLayerSpecification,
-  FillLayerSpecification,
-  FillExtrusionLayerSpecification,
-  LineLayerSpecification,
-  SymbolLayerSpecification,
-  RasterLayerSpecification,
-  CircleLayerSpecification,
-  FilterSpecification,
-  TerrainSpecification,
-  QueryRenderedFeaturesOptions,
+  type AnimationOptions,
+  type LayerSpecification,
+  type StyleSpecification,
+  type LngLatBoundsLike,
+  type PointLike,
+  type IControl,
+  type SourceSpecification,
+  type FitBoundsOptions,
+  type Source,
+  type BackgroundLayerSpecification,
+  type FillLayerSpecification,
+  type FillExtrusionLayerSpecification,
+  type LineLayerSpecification,
+  type SymbolLayerSpecification,
+  type RasterLayerSpecification,
+  type CircleLayerSpecification,
+  type FilterSpecification,
+  type TerrainSpecification,
+  type QueryRenderedFeaturesOptions,
 } from 'maplibre-gl';
 import { AsyncSubject, Subscription } from 'rxjs';
 import { first } from 'rxjs/operators';
-import {
+import type {
   LayerEvents,
   MapEvent,
   MapImageData,
@@ -94,15 +100,15 @@ export class MapService {
   mapInstance: Map;
   mapEvents: MapEvent;
 
-  private mapCreated = new AsyncSubject<void>();
-  private mapLoaded = new AsyncSubject<void>();
-  private markersToRemove: Marker[] = [];
-  private popupsToRemove: Popup[] = [];
-  private imageIdsToRemove: string[] = [];
-  private subscription = new Subscription();
+  private readonly mapCreated = new AsyncSubject<void>();
+  private readonly mapLoaded = new AsyncSubject<void>();
+  private readonly markersToRemove = signal<Marker[]>([]);
+  private readonly popupsToRemove = signal<Popup[]>([]);
+  private readonly imageIdsToRemove = signal<string[]>([]);
+  private readonly subscription = new Subscription();
 
-  mapCreated$ = this.mapCreated.asObservable();
-  mapLoaded$ = this.mapLoaded.asObservable();
+  readonly mapCreated$ = this.mapCreated.asObservable();
+  readonly mapLoaded$ = this.mapLoaded.asObservable();
 
   setup(options: SetupMap) {
     // Need onStable to wait for a potential @angular/route transition to end
@@ -426,7 +432,7 @@ export class MapService {
   }
 
   removeMarker(marker: Marker) {
-    this.markersToRemove.push(marker);
+    this.markersToRemove.update((markers) => [...markers, marker]);
   }
 
   createPopup(popup: SetupPopup, element: Node) {
@@ -472,7 +478,7 @@ export class MapService {
     if (skipCloseEvent && popup._listeners) {
       delete popup._listeners['close'];
     }
-    this.popupsToRemove.push(popup);
+    this.popupsToRemove.update((popups) => [...popups, popup]);
   }
 
   removePopupFromMarker(marker: Marker) {
@@ -514,7 +520,7 @@ export class MapService {
   }
 
   removeImage(imageId: string) {
-    this.imageIdsToRemove.push(imageId);
+    this.imageIdsToRemove.update((imagesIds) => [...imagesIds, imageId]);
   }
 
   addSource(sourceId: string, source: SourceSpecification) {
@@ -654,24 +660,24 @@ export class MapService {
   }
 
   private removeMarkers() {
-    for (const marker of this.markersToRemove) {
+    for (const marker of this.markersToRemove()) {
       marker.remove();
     }
-    this.markersToRemove = [];
+    this.markersToRemove.set([]);
   }
 
   private removePopups() {
-    for (const popup of this.popupsToRemove) {
+    for (const popup of this.popupsToRemove()) {
       popup.remove();
     }
-    this.popupsToRemove = [];
+    this.popupsToRemove.set([]);
   }
 
   private removeImages() {
-    for (const imageId of this.imageIdsToRemove) {
+    for (const imageId of this.imageIdsToRemove()) {
       this.mapInstance.removeImage(imageId);
     }
-    this.imageIdsToRemove = [];
+    this.imageIdsToRemove.set([]);
   }
 
   private findLayersBySourceId(sourceId: string): LayerSpecification[] {

--- a/projects/ngx-maplibre-gl/src/lib/map/map.service.ts
+++ b/projects/ngx-maplibre-gl/src/lib/map/map.service.ts
@@ -44,7 +44,7 @@ import type {
   MapImageData,
   MapImageOptions,
 } from './map.types';
-import { keepAvailableObjectValues } from '../shared';
+import { keepAvailableObjectValues } from '../shared/utils/functions/object.fn';
 
 export interface SetupMap {
   mapOptions: Omit<MapOptions, 'bearing' | 'pitch' | 'zoom'> & {

--- a/projects/ngx-maplibre-gl/src/lib/map/map.service.ts
+++ b/projects/ngx-maplibre-gl/src/lib/map/map.service.ts
@@ -1,4 +1,4 @@
-import { EventEmitter, Injectable, NgZone } from '@angular/core';
+import { Injectable, NgZone, OutputEmitterRef, inject } from '@angular/core';
 import {
   CameraOptions,
   FlyToOptions,
@@ -29,7 +29,7 @@ import {
   TerrainSpecification,
   QueryRenderedFeaturesOptions,
 } from 'maplibre-gl';
-import { AsyncSubject, Observable, Subscription } from 'rxjs';
+import { AsyncSubject, Subscription } from 'rxjs';
 import { first } from 'rxjs/operators';
 import {
   LayerEvents,
@@ -56,8 +56,8 @@ export interface SetupLayer {
 export interface SetupPopup {
   popupOptions: PopupOptions;
   popupEvents: {
-    popupOpen: EventEmitter<void>;
-    popupClose: EventEmitter<void>;
+    popupOpen: OutputEmitterRef<void>;
+    popupClose: OutputEmitterRef<void>;
   };
 }
 
@@ -76,9 +76,9 @@ export interface SetupMarker {
     clickTolerance?: MarkerOptions['clickTolerance'];
   };
   markersEvents: {
-    markerDragStart: EventEmitter<Marker>;
-    markerDrag: EventEmitter<Marker>;
-    markerDragEnd: EventEmitter<Marker>;
+    markerDragStart: OutputEmitterRef<Marker>;
+    markerDrag: OutputEmitterRef<Marker>;
+    markerDragEnd: OutputEmitterRef<Marker>;
   };
 }
 
@@ -89,9 +89,9 @@ export type MovingOptions =
 
 @Injectable()
 export class MapService {
+  private readonly zone = inject(NgZone);
+
   mapInstance: Map;
-  mapCreated$: Observable<void>;
-  mapLoaded$: Observable<void>;
   mapEvents: MapEvent;
 
   private mapCreated = new AsyncSubject<void>();
@@ -101,10 +101,8 @@ export class MapService {
   private imageIdsToRemove: string[] = [];
   private subscription = new Subscription();
 
-  constructor(private zone: NgZone) {
-    this.mapCreated$ = this.mapCreated.asObservable();
-    this.mapLoaded$ = this.mapLoaded.asObservable();
-  }
+  mapCreated$ = this.mapCreated.asObservable();
+  mapLoaded$ = this.mapLoaded.asObservable();
 
   setup(options: SetupMap) {
     // Need onStable to wait for a potential @angular/route transition to end
@@ -302,97 +300,71 @@ export class MapService {
         before
       );
       if (bindEvents) {
-        if (layer.layerEvents.layerClick.observers.length) {
-          this.mapInstance.on('click', layer.layerOptions.id, (evt) => {
-            this.zone.run(() => {
-              layer.layerEvents.layerClick.emit(evt);
-            });
+        this.mapInstance.on('click', layer.layerOptions.id, (evt) => {
+          this.zone.run(() => {
+            layer.layerEvents.layerClick.emit(evt);
           });
-        }
-        if (layer.layerEvents.layerDblClick.observers.length) {
-          this.mapInstance.on('dblclick', layer.layerOptions.id, (evt) => {
-            this.zone.run(() => {
-              layer.layerEvents.layerDblClick.emit(evt);
-            });
+        });
+        this.mapInstance.on('dblclick', layer.layerOptions.id, (evt) => {
+          this.zone.run(() => {
+            layer.layerEvents.layerDblClick.emit(evt);
           });
-        }
-        if (layer.layerEvents.layerMouseDown.observers.length) {
-          this.mapInstance.on('mousedown', layer.layerOptions.id, (evt) => {
-            this.zone.run(() => {
-              layer.layerEvents.layerMouseDown.emit(evt);
-            });
+        });
+        this.mapInstance.on('mousedown', layer.layerOptions.id, (evt) => {
+          this.zone.run(() => {
+            layer.layerEvents.layerMouseDown.emit(evt);
           });
-        }
-        if (layer.layerEvents.layerMouseUp.observers.length) {
-          this.mapInstance.on('mouseup', layer.layerOptions.id, (evt) => {
-            this.zone.run(() => {
-              layer.layerEvents.layerMouseUp.emit(evt);
-            });
+        });
+        this.mapInstance.on('mouseup', layer.layerOptions.id, (evt) => {
+          this.zone.run(() => {
+            layer.layerEvents.layerMouseUp.emit(evt);
           });
-        }
-        if (layer.layerEvents.layerMouseEnter.observers.length) {
-          this.mapInstance.on('mouseenter', layer.layerOptions.id, (evt) => {
-            this.zone.run(() => {
-              layer.layerEvents.layerMouseEnter.emit(evt);
-            });
+        });
+        this.mapInstance.on('mouseenter', layer.layerOptions.id, (evt) => {
+          this.zone.run(() => {
+            layer.layerEvents.layerMouseEnter.emit(evt);
           });
-        }
-        if (layer.layerEvents.layerMouseLeave.observers.length) {
-          this.mapInstance.on('mouseleave', layer.layerOptions.id, (evt) => {
-            this.zone.run(() => {
-              layer.layerEvents.layerMouseLeave.emit(evt);
-            });
+        });
+        this.mapInstance.on('mouseleave', layer.layerOptions.id, (evt) => {
+          this.zone.run(() => {
+            layer.layerEvents.layerMouseLeave.emit(evt);
           });
-        }
-        if (layer.layerEvents.layerMouseMove.observers.length) {
-          this.mapInstance.on('mousemove', layer.layerOptions.id, (evt) => {
-            this.zone.run(() => {
-              layer.layerEvents.layerMouseMove.emit(evt);
-            });
+        });
+        this.mapInstance.on('mousemove', layer.layerOptions.id, (evt) => {
+          this.zone.run(() => {
+            layer.layerEvents.layerMouseMove.emit(evt);
           });
-        }
-        if (layer.layerEvents.layerMouseOver.observers.length) {
-          this.mapInstance.on('mouseover', layer.layerOptions.id, (evt) => {
-            this.zone.run(() => {
-              layer.layerEvents.layerMouseOver.emit(evt);
-            });
+        });
+        this.mapInstance.on('mouseover', layer.layerOptions.id, (evt) => {
+          this.zone.run(() => {
+            layer.layerEvents.layerMouseOver.emit(evt);
           });
-        }
-        if (layer.layerEvents.layerMouseOut.observers.length) {
-          this.mapInstance.on('mouseout', layer.layerOptions.id, (evt) => {
-            this.zone.run(() => {
-              layer.layerEvents.layerMouseOut.emit(evt);
-            });
+        });
+        this.mapInstance.on('mouseout', layer.layerOptions.id, (evt) => {
+          this.zone.run(() => {
+            layer.layerEvents.layerMouseOut.emit(evt);
           });
-        }
-        if (layer.layerEvents.layerContextMenu.observers.length) {
-          this.mapInstance.on('contextmenu', layer.layerOptions.id, (evt) => {
-            this.zone.run(() => {
-              layer.layerEvents.layerContextMenu.emit(evt);
-            });
+        });
+        this.mapInstance.on('contextmenu', layer.layerOptions.id, (evt) => {
+          this.zone.run(() => {
+            layer.layerEvents.layerContextMenu.emit(evt);
           });
-        }
-        if (layer.layerEvents.layerTouchStart.observers.length) {
-          this.mapInstance.on('touchstart', layer.layerOptions.id, (evt) => {
-            this.zone.run(() => {
-              layer.layerEvents.layerTouchStart.emit(evt);
-            });
+        });
+        this.mapInstance.on('touchstart', layer.layerOptions.id, (evt) => {
+          this.zone.run(() => {
+            layer.layerEvents.layerTouchStart.emit(evt);
           });
-        }
-        if (layer.layerEvents.layerTouchEnd.observers.length) {
-          this.mapInstance.on('touchend', layer.layerOptions.id, (evt) => {
-            this.zone.run(() => {
-              layer.layerEvents.layerTouchEnd.emit(evt);
-            });
+        });
+        this.mapInstance.on('touchend', layer.layerOptions.id, (evt) => {
+          this.zone.run(() => {
+            layer.layerEvents.layerTouchEnd.emit(evt);
           });
-        }
-        if (layer.layerEvents.layerTouchCancel.observers.length) {
-          this.mapInstance.on('touchcancel', layer.layerOptions.id, (evt) => {
-            this.zone.run(() => {
-              layer.layerEvents.layerTouchCancel.emit(evt);
-            });
+        });
+        this.mapInstance.on('touchcancel', layer.layerOptions.id, (evt) => {
+          this.zone.run(() => {
+            layer.layerEvents.layerTouchCancel.emit(evt);
           });
-        }
+        });
       }
     });
   }
@@ -420,39 +392,29 @@ export class MapService {
       options.element = marker.markersOptions.element;
     }
     const markerInstance = new Marker(options);
-    if (marker.markersEvents.markerDragStart.observers.length) {
-      markerInstance.on('dragstart', (event: { target: Marker }) => {
-        if (event) {
-          const { target } = event;
-          this.zone.run(() => {
-            marker.markersEvents.markerDragStart.emit(target);
-          });
-        }
-      });
-    }
+    markerInstance.on('dragstart', (event: { target: Marker }) => {
+      if (event) {
+        const { target } = event;
+        this.zone.run(() => {
+          marker.markersEvents.markerDragStart.emit(target);
+        });
+      }
+    });
     /*
 
      */
-    if (marker.markersEvents.markerDrag.observers.length) {
-      markerInstance.on('drag', (event: { target: Marker }) => {
-        if (event) {
-          const { target } = event;
-          this.zone.run(() => {
-            marker.markersEvents.markerDrag.emit(target);
-          });
-        }
-      });
-    }
-    if (marker.markersEvents.markerDragEnd.observers.length) {
-      markerInstance.on('dragend', (event: { target: Marker }) => {
-        if (event) {
-          const { target } = event;
-          this.zone.run(() => {
-            marker.markersEvents.markerDragEnd.emit(target);
-          });
-        }
-      });
-    }
+    markerInstance.on('drag', (event: { target: Marker }) => {
+      if (event) {
+        const { target } = event;
+        this.zone.run(() => marker.markersEvents.markerDrag.emit(target));
+      }
+    });
+    markerInstance.on('dragend', (event: { target: Marker }) => {
+      if (event) {
+        const { target } = event;
+        this.zone.run(() => marker.markersEvents.markerDragEnd.emit(target));
+      }
+    });
     const lngLat: LngLatLike = marker.markersOptions.feature
       ? <[number, number]>marker.markersOptions.feature.geometry!.coordinates
       : marker.markersOptions.lngLat!;
@@ -476,20 +438,16 @@ export class MapService {
       );
       const popupInstance = new Popup(popup.popupOptions);
       popupInstance.setDOMContent(element);
-      if (popup.popupEvents.popupClose.observers.length) {
-        popupInstance.on('close', () => {
-          this.zone.run(() => {
-            popup.popupEvents.popupClose.emit();
-          });
+      popupInstance.on('close', () => {
+        this.zone.run(() => {
+          popup.popupEvents.popupClose.emit();
         });
-      }
-      if (popup.popupEvents.popupOpen.observers.length) {
-        popupInstance.on('open', () => {
-          this.zone.run(() => {
-            popup.popupEvents.popupOpen.emit();
-          });
+      });
+      popupInstance.on('open', () => {
+        this.zone.run(() => {
+          popup.popupEvents.popupOpen.emit();
         });
-      }
+      });
       return popupInstance;
     });
   }
@@ -544,8 +502,8 @@ export class MapService {
     options?: MapImageOptions
   ) {
     return this.zone.runOutsideAngular(async () => {
-        const image = await this.mapInstance.loadImage(url);
-        this.addImage(imageId, image.data, options);
+      const image = await this.mapInstance.loadImage(url);
+      this.addImage(imageId, image.data, options);
     });
   }
 
@@ -735,268 +693,178 @@ export class MapService {
         events.mapLoad.emit(evt.target);
       });
     });
-    if (events.mapResize.observers.length) {
-      this.mapInstance.on('resize', (evt) =>
-        this.zone.run(() => {
-          events.mapResize.emit(evt);
-        })
-      );
-    }
-    if (events.mapRemove.observers.length) {
-      this.mapInstance.on('remove', (evt) =>
-        this.zone.run(() => {
-          events.mapRemove.emit(evt);
-        })
-      );
-    }
-    if (events.mapMouseDown.observers.length) {
-      this.mapInstance.on('mousedown', (evt) =>
-        this.zone.run(() => {
-          events.mapMouseDown.emit(evt);
-        })
-      );
-    }
-    if (events.mapMouseUp.observers.length) {
-      this.mapInstance.on('mouseup', (evt) =>
-        this.zone.run(() => {
-          events.mapMouseUp.emit(evt);
-        })
-      );
-    }
-    if (events.mapMouseMove.observers.length) {
-      this.mapInstance.on('mousemove', (evt) =>
-        this.zone.run(() => {
-          events.mapMouseMove.emit(evt);
-        })
-      );
-    }
-    if (events.mapClick.observers.length) {
-      this.mapInstance.on('click', (evt) =>
-        this.zone.run(() => {
-          events.mapClick.emit(evt);
-        })
-      );
-    }
-    if (events.mapDblClick.observers.length) {
-      this.mapInstance.on('dblclick', (evt) =>
-        this.zone.run(() => {
-          events.mapDblClick.emit(evt);
-        })
-      );
-    }
-    if (events.mapMouseOver.observers.length) {
-      this.mapInstance.on('mouseover', (evt) =>
-        this.zone.run(() => {
-          events.mapMouseOver.emit(evt);
-        })
-      );
-    }
-    if (events.mapMouseOut.observers.length) {
-      this.mapInstance.on('mouseout', (evt) =>
-        this.zone.run(() => {
-          events.mapMouseOut.emit(evt);
-        })
-      );
-    }
-    if (events.mapContextMenu.observers.length) {
-      this.mapInstance.on('contextmenu', (evt) =>
-        this.zone.run(() => {
-          events.mapContextMenu.emit(evt);
-        })
-      );
-    }
-    if (events.mapTouchStart.observers.length) {
-      this.mapInstance.on('touchstart', (evt) =>
-        this.zone.run(() => {
-          events.mapTouchStart.emit(evt);
-        })
-      );
-    }
-    if (events.mapTouchEnd.observers.length) {
-      this.mapInstance.on('touchend', (evt) =>
-        this.zone.run(() => {
-          events.mapTouchEnd.emit(evt);
-        })
-      );
-    }
-    if (events.mapTouchMove.observers.length) {
-      this.mapInstance.on('touchmove', (evt) =>
-        this.zone.run(() => {
-          events.mapTouchMove.emit(evt);
-        })
-      );
-    }
-    if (events.mapTouchCancel.observers.length) {
-      this.mapInstance.on('touchcancel', (evt) =>
-        this.zone.run(() => {
-          events.mapTouchCancel.emit(evt);
-        })
-      );
-    }
-    if (events.mapWheel.observers.length) {
-      this.mapInstance.on('wheel', (evt) =>
-        this.zone.run(() => {
-          events.mapWheel.emit(evt);
-        })
-      );
-    }
-    if (events.moveStart.observers.length) {
-      this.mapInstance.on('movestart', (evt) =>
-        this.zone.run(() => events.moveStart.emit(evt))
-      );
-    }
-    if (events.move.observers.length) {
-      this.mapInstance.on('move', (evt) =>
-        this.zone.run(() => events.move.emit(evt))
-      );
-    }
-    if (events.moveEnd.observers.length) {
-      this.mapInstance.on('moveend', (evt) =>
-        this.zone.run(() => events.moveEnd.emit(evt))
-      );
-    }
-    if (events.mapDragStart.observers.length) {
-      this.mapInstance.on('dragstart', (evt) =>
-        this.zone.run(() => {
-          events.mapDragStart.emit(evt);
-        })
-      );
-    }
-    if (events.mapDrag.observers.length) {
-      this.mapInstance.on('drag', (evt) =>
-        this.zone.run(() => {
-          events.mapDrag.emit(evt);
-        })
-      );
-    }
-    if (events.mapDragEnd.observers.length) {
-      this.mapInstance.on('dragend', (evt) =>
-        this.zone.run(() => {
-          events.mapDragEnd.emit(evt);
-        })
-      );
-    }
-    if (events.zoomStart.observers.length) {
-      this.mapInstance.on('zoomstart', (evt) =>
-        this.zone.run(() => events.zoomStart.emit(evt))
-      );
-    }
-    if (events.zoomEvt.observers.length) {
-      this.mapInstance.on('zoom', (evt) =>
-        this.zone.run(() => events.zoomEvt.emit(evt))
-      );
-    }
-    if (events.zoomEnd.observers.length) {
-      this.mapInstance.on('zoomend', (evt) =>
-        this.zone.run(() => events.zoomEnd.emit(evt))
-      );
-    }
-    if (events.rotateStart.observers.length) {
-      this.mapInstance.on('rotatestart', (evt) =>
-        this.zone.run(() => events.rotateStart.emit(evt))
-      );
-    }
-    if (events.rotate.observers.length) {
-      this.mapInstance.on('rotate', (evt) =>
-        this.zone.run(() => events.rotate.emit(evt))
-      );
-    }
-    if (events.rotateEnd.observers.length) {
-      this.mapInstance.on('rotateend', (evt) =>
-        this.zone.run(() => events.rotateEnd.emit(evt))
-      );
-    }
-    if (events.pitchStart.observers.length) {
-      this.mapInstance.on('pitchstart', (evt) =>
-        this.zone.run(() => events.pitchStart.emit(evt))
-      );
-    }
-    if (events.pitchEvt.observers.length) {
-      this.mapInstance.on('pitch', (evt) =>
-        this.zone.run(() => events.pitchEvt.emit(evt))
-      );
-    }
-    if (events.pitchEnd.observers.length) {
-      this.mapInstance.on('pitchend', (evt) =>
-        this.zone.run(() => events.pitchEnd.emit(evt))
-      );
-    }
-    if (events.boxZoomStart.observers.length) {
-      this.mapInstance.on('boxzoomstart', (evt) =>
-        this.zone.run(() => events.boxZoomStart.emit(evt))
-      );
-    }
-    if (events.boxZoomEnd.observers.length) {
-      this.mapInstance.on('boxzoomend', (evt) =>
-        this.zone.run(() => events.boxZoomEnd.emit(evt))
-      );
-    }
-    if (events.boxZoomCancel.observers.length) {
-      this.mapInstance.on('boxzoomcancel', (evt) =>
-        this.zone.run(() => events.boxZoomCancel.emit(evt))
-      );
-    }
-    if (events.webGlContextLost.observers.length) {
-      this.mapInstance.on('webglcontextlost', (evt) =>
-        this.zone.run(() => events.webGlContextLost.emit(evt))
-      );
-    }
-    if (events.webGlContextRestored.observers.length) {
-      this.mapInstance.on('webglcontextrestored', (evt) =>
-        this.zone.run(() => events.webGlContextRestored.emit(evt))
-      );
-    }
-    if (events.render.observers.length) {
-      this.mapInstance.on('render', (evt) =>
-        this.zone.run(() => events.render.emit(evt))
-      );
-    }
-    if (events.mapError.observers.length) {
-      this.mapInstance.on('error', (evt) =>
-        this.zone.run(() => {
-          events.mapError.emit(evt);
-        })
-      );
-    }
-    if (events.data.observers.length) {
-      this.mapInstance.on('data', (evt) =>
-        this.zone.run(() => events.data.emit(evt))
-      );
-    }
-    if (events.styleData.observers.length) {
-      this.mapInstance.on('styledata', (evt) =>
-        this.zone.run(() => events.styleData.emit(evt))
-      );
-    }
-    if (events.sourceData.observers.length) {
-      this.mapInstance.on('sourcedata', (evt) =>
-        this.zone.run(() => events.sourceData.emit(evt))
-      );
-    }
-    if (events.dataLoading.observers.length) {
-      this.mapInstance.on('dataloading', (evt) =>
-        this.zone.run(() => events.dataLoading.emit(evt))
-      );
-    }
-    if (events.styleDataLoading.observers.length) {
-      this.mapInstance.on('styledataloading', (evt) =>
-        this.zone.run(() => events.styleDataLoading.emit(evt))
-      );
-    }
-    if (events.sourceDataLoading.observers.length) {
-      this.mapInstance.on('sourcedataloading', (evt) =>
-        this.zone.run(() => events.sourceDataLoading.emit(evt))
-      );
-    }
-    if (events.styleImageMissing.observers.length) {
-      this.mapInstance.on('styleimagemissing', (evt) =>
-        this.zone.run(() => events.styleImageMissing.emit(evt))
-      );
-    }
-    if (events.idle.observers.length) {
-      this.mapInstance.on('idle', (evt) =>
-        this.zone.run(() => events.idle.emit(evt))
-      );
-    }
+    this.mapInstance.on('resize', (evt) =>
+      this.zone.run(() => {
+        events.mapResize.emit(evt);
+      })
+    );
+    this.mapInstance.on('remove', (evt) =>
+      this.zone.run(() => {
+        events.mapRemove.emit(evt);
+      })
+    );
+    this.mapInstance.on('mousedown', (evt) =>
+      this.zone.run(() => {
+        events.mapMouseDown.emit(evt);
+      })
+    );
+    this.mapInstance.on('mouseup', (evt) =>
+      this.zone.run(() => {
+        events.mapMouseUp.emit(evt);
+      })
+    );
+    this.mapInstance.on('mousemove', (evt) =>
+      this.zone.run(() => {
+        events.mapMouseMove.emit(evt);
+      })
+    );
+    this.mapInstance.on('click', (evt) =>
+      this.zone.run(() => {
+        events.mapClick.emit(evt);
+      })
+    );
+    this.mapInstance.on('dblclick', (evt) =>
+      this.zone.run(() => {
+        events.mapDblClick.emit(evt);
+      })
+    );
+    this.mapInstance.on('mouseover', (evt) =>
+      this.zone.run(() => {
+        events.mapMouseOver.emit(evt);
+      })
+    );
+    this.mapInstance.on('mouseout', (evt) =>
+      this.zone.run(() => {
+        events.mapMouseOut.emit(evt);
+      })
+    );
+    this.mapInstance.on('contextmenu', (evt) =>
+      this.zone.run(() => {
+        events.mapContextMenu.emit(evt);
+      })
+    );
+    this.mapInstance.on('touchstart', (evt) =>
+      this.zone.run(() => {
+        events.mapTouchStart.emit(evt);
+      })
+    );
+    this.mapInstance.on('touchend', (evt) =>
+      this.zone.run(() => {
+        events.mapTouchEnd.emit(evt);
+      })
+    );
+    this.mapInstance.on('touchmove', (evt) =>
+      this.zone.run(() => {
+        events.mapTouchMove.emit(evt);
+      })
+    );
+    this.mapInstance.on('touchcancel', (evt) =>
+      this.zone.run(() => {
+        events.mapTouchCancel.emit(evt);
+      })
+    );
+    this.mapInstance.on('wheel', (evt) =>
+      this.zone.run(() => {
+        events.mapWheel.emit(evt);
+      })
+    );
+    this.mapInstance.on('movestart', (evt) =>
+      this.zone.run(() => events.moveStart.emit(evt))
+    );
+    this.mapInstance.on('move', (evt) =>
+      this.zone.run(() => events.move.emit(evt))
+    );
+    this.mapInstance.on('moveend', (evt) =>
+      this.zone.run(() => events.moveEnd.emit(evt))
+    );
+    this.mapInstance.on('dragstart', (evt) =>
+      this.zone.run(() => {
+        events.mapDragStart.emit(evt);
+      })
+    );
+    this.mapInstance.on('drag', (evt) =>
+      this.zone.run(() => {
+        events.mapDrag.emit(evt);
+      })
+    );
+    this.mapInstance.on('dragend', (evt) =>
+      this.zone.run(() => {
+        events.mapDragEnd.emit(evt);
+      })
+    );
+    this.mapInstance.on('zoomstart', (evt) =>
+      this.zone.run(() => events.zoomStart.emit(evt))
+    );
+    this.mapInstance.on('zoom', (evt) =>
+      this.zone.run(() => events.zoomEvt.emit(evt))
+    );
+    this.mapInstance.on('zoomend', (evt) =>
+      this.zone.run(() => events.zoomEnd.emit(evt))
+    );
+    this.mapInstance.on('rotatestart', (evt) =>
+      this.zone.run(() => events.rotateStart.emit(evt))
+    );
+    this.mapInstance.on('rotate', (evt) =>
+      this.zone.run(() => events.rotate.emit(evt))
+    );
+    this.mapInstance.on('rotateend', (evt) =>
+      this.zone.run(() => events.rotateEnd.emit(evt))
+    );
+    this.mapInstance.on('pitchstart', (evt) =>
+      this.zone.run(() => events.pitchStart.emit(evt))
+    );
+    this.mapInstance.on('pitch', (evt) =>
+      this.zone.run(() => events.pitchEvt.emit(evt))
+    );
+    this.mapInstance.on('pitchend', (evt) =>
+      this.zone.run(() => events.pitchEnd.emit(evt))
+    );
+    this.mapInstance.on('boxzoomstart', (evt) =>
+      this.zone.run(() => events.boxZoomStart.emit(evt))
+    );
+    this.mapInstance.on('boxzoomend', (evt) =>
+      this.zone.run(() => events.boxZoomEnd.emit(evt))
+    );
+    this.mapInstance.on('boxzoomcancel', (evt) =>
+      this.zone.run(() => events.boxZoomCancel.emit(evt))
+    );
+    this.mapInstance.on('webglcontextlost', (evt) =>
+      this.zone.run(() => events.webGlContextLost.emit(evt))
+    );
+    this.mapInstance.on('webglcontextrestored', (evt) =>
+      this.zone.run(() => events.webGlContextRestored.emit(evt))
+    );
+    this.mapInstance.on('render', (evt) =>
+      this.zone.run(() => events.render.emit(evt))
+    );
+    this.mapInstance.on('error', (evt) =>
+      this.zone.run(() => {
+        events.mapError.emit(evt);
+      })
+    );
+    this.mapInstance.on('data', (evt) =>
+      this.zone.run(() => events.data.emit(evt))
+    );
+    this.mapInstance.on('styledata', (evt) =>
+      this.zone.run(() => events.styleData.emit(evt))
+    );
+    this.mapInstance.on('sourcedata', (evt) =>
+      this.zone.run(() => events.sourceData.emit(evt))
+    );
+    this.mapInstance.on('dataloading', (evt) =>
+      this.zone.run(() => events.dataLoading.emit(evt))
+    );
+    this.mapInstance.on('styledataloading', (evt) =>
+      this.zone.run(() => events.styleDataLoading.emit(evt))
+    );
+    this.mapInstance.on('sourcedataloading', (evt) =>
+      this.zone.run(() => events.sourceDataLoading.emit(evt))
+    );
+    this.mapInstance.on('styleimagemissing', (evt) =>
+      this.zone.run(() => events.styleImageMissing.emit(evt))
+    );
+    this.mapInstance.on('idle', (evt) =>
+      this.zone.run(() => events.idle.emit(evt))
+    );
   }
 }

--- a/projects/ngx-maplibre-gl/src/lib/map/map.types.ts
+++ b/projects/ngx-maplibre-gl/src/lib/map/map.types.ts
@@ -1,6 +1,6 @@
 // Can't use MapEvent interface because some event name are changed (eg zoomChange)
 import { OutputEmitterRef } from '@angular/core';
-import {
+import type {
   GeolocateControl,
   Map,
   MapLibreEvent,

--- a/projects/ngx-maplibre-gl/src/lib/map/map.types.ts
+++ b/projects/ngx-maplibre-gl/src/lib/map/map.types.ts
@@ -1,5 +1,5 @@
 // Can't use MapEvent interface because some event name are changed (eg zoomChange)
-import { EventEmitter } from '@angular/core';
+import { OutputEmitterRef } from '@angular/core';
 import {
   GeolocateControl,
   Map,
@@ -21,98 +21,98 @@ export interface EventData {
 }
 
 export interface MapEvent {
-  mapResize: EventEmitter<MapLibreEvent & EventData>;
-  mapRemove: EventEmitter<MapLibreEvent & EventData>;
-  mapMouseDown: EventEmitter<MapMouseEvent & EventData>;
-  mapMouseUp: EventEmitter<MapMouseEvent & EventData>;
-  mapMouseMove: EventEmitter<MapMouseEvent & EventData>;
-  mapClick: EventEmitter<MapMouseEvent & EventData>;
-  mapDblClick: EventEmitter<MapMouseEvent & EventData>;
-  mapMouseOver: EventEmitter<MapMouseEvent & EventData>;
-  mapMouseOut: EventEmitter<MapMouseEvent & EventData>;
-  mapContextMenu: EventEmitter<MapMouseEvent & EventData>;
-  mapTouchStart: EventEmitter<MapTouchEvent & EventData>;
-  mapTouchEnd: EventEmitter<MapTouchEvent & EventData>;
-  mapTouchMove: EventEmitter<MapTouchEvent & EventData>;
-  mapTouchCancel: EventEmitter<MapTouchEvent & EventData>;
-  mapWheel: EventEmitter<MapWheelEvent & EventData>;
-  moveStart: EventEmitter<
+  mapResize: OutputEmitterRef<MapLibreEvent & EventData>;
+  mapRemove: OutputEmitterRef<MapLibreEvent & EventData>;
+  mapMouseDown: OutputEmitterRef<MapMouseEvent & EventData>;
+  mapMouseUp: OutputEmitterRef<MapMouseEvent & EventData>;
+  mapMouseMove: OutputEmitterRef<MapMouseEvent & EventData>;
+  mapClick: OutputEmitterRef<MapMouseEvent & EventData>;
+  mapDblClick: OutputEmitterRef<MapMouseEvent & EventData>;
+  mapMouseOver: OutputEmitterRef<MapMouseEvent & EventData>;
+  mapMouseOut: OutputEmitterRef<MapMouseEvent & EventData>;
+  mapContextMenu: OutputEmitterRef<MapMouseEvent & EventData>;
+  mapTouchStart: OutputEmitterRef<MapTouchEvent & EventData>;
+  mapTouchEnd: OutputEmitterRef<MapTouchEvent & EventData>;
+  mapTouchMove: OutputEmitterRef<MapTouchEvent & EventData>;
+  mapTouchCancel: OutputEmitterRef<MapTouchEvent & EventData>;
+  mapWheel: OutputEmitterRef<MapWheelEvent & EventData>;
+  moveStart: OutputEmitterRef<
     MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined> & EventData
   >;
-  move: EventEmitter<
+  move: OutputEmitterRef<
     MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined> & EventData
   >;
-  moveEnd: EventEmitter<
+  moveEnd: OutputEmitterRef<
     MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined> & EventData
   >;
-  mapDragStart: EventEmitter<
+  mapDragStart: OutputEmitterRef<
     MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
   >;
-  mapDrag: EventEmitter<
+  mapDrag: OutputEmitterRef<
     MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
   >;
-  mapDragEnd: EventEmitter<
+  mapDragEnd: OutputEmitterRef<
     MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
   >;
-  zoomStart: EventEmitter<
+  zoomStart: OutputEmitterRef<
     MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined> & EventData
   >;
-  zoomEvt: EventEmitter<
+  zoomEvt: OutputEmitterRef<
     MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined> & EventData
   >;
-  zoomEnd: EventEmitter<
+  zoomEnd: OutputEmitterRef<
     MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined> & EventData
   >;
-  rotateStart: EventEmitter<
+  rotateStart: OutputEmitterRef<
     MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
   >;
-  rotate: EventEmitter<
+  rotate: OutputEmitterRef<
     MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
   >;
-  rotateEnd: EventEmitter<
+  rotateEnd: OutputEmitterRef<
     MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
   >;
-  pitchStart: EventEmitter<
+  pitchStart: OutputEmitterRef<
     MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
   >;
-  pitchEvt: EventEmitter<
+  pitchEvt: OutputEmitterRef<
     MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
   >;
-  pitchEnd: EventEmitter<
+  pitchEnd: OutputEmitterRef<
     MapLibreEvent<MouseEvent | TouchEvent | undefined> & EventData
   >;
-  boxZoomStart: EventEmitter<MapLibreZoomEvent & EventData>;
-  boxZoomEnd: EventEmitter<MapLibreZoomEvent & EventData>;
-  boxZoomCancel: EventEmitter<MapLibreZoomEvent & EventData>;
-  webGlContextLost: EventEmitter<MapContextEvent & EventData>;
-  webGlContextRestored: EventEmitter<MapContextEvent & EventData>;
-  mapLoad: EventEmitter<Map>; // Consider emitting MapLibreEvent for consistency (breaking change).
-  render: EventEmitter<MapLibreEvent & EventData>;
-  mapError: EventEmitter<ErrorEvent & EventData>;
-  data: EventEmitter<MapDataEvent & EventData>;
-  styleData: EventEmitter<MapStyleDataEvent & EventData>;
-  sourceData: EventEmitter<MapSourceDataEvent & EventData>;
-  dataLoading: EventEmitter<MapDataEvent & EventData>;
-  styleDataLoading: EventEmitter<MapStyleDataEvent & EventData>;
-  sourceDataLoading: EventEmitter<MapSourceDataEvent & EventData>;
-  styleImageMissing: EventEmitter<{ id: string } & EventData>;
-  idle: EventEmitter<MapLibreEvent & EventData>;
+  boxZoomStart: OutputEmitterRef<MapLibreZoomEvent & EventData>;
+  boxZoomEnd: OutputEmitterRef<MapLibreZoomEvent & EventData>;
+  boxZoomCancel: OutputEmitterRef<MapLibreZoomEvent & EventData>;
+  webGlContextLost: OutputEmitterRef<MapContextEvent & EventData>;
+  webGlContextRestored: OutputEmitterRef<MapContextEvent & EventData>;
+  mapLoad: OutputEmitterRef<Map>; // Consider emitting MapLibreEvent for consistency (breaking change).
+  render: OutputEmitterRef<MapLibreEvent & EventData>;
+  mapError: OutputEmitterRef<ErrorEvent & EventData>;
+  data: OutputEmitterRef<MapDataEvent & EventData>;
+  styleData: OutputEmitterRef<MapStyleDataEvent & EventData>;
+  sourceData: OutputEmitterRef<MapSourceDataEvent & EventData>;
+  dataLoading: OutputEmitterRef<MapDataEvent & EventData>;
+  styleDataLoading: OutputEmitterRef<MapStyleDataEvent & EventData>;
+  sourceDataLoading: OutputEmitterRef<MapSourceDataEvent & EventData>;
+  styleImageMissing: OutputEmitterRef<{ id: string } & EventData>;
+  idle: OutputEmitterRef<MapLibreEvent & EventData>;
 }
 
 export interface LayerEvents {
-  layerClick: EventEmitter<MapLayerMouseEvent & EventData>;
-  layerDblClick: EventEmitter<MapLayerMouseEvent & EventData>;
-  layerMouseDown: EventEmitter<MapLayerMouseEvent & EventData>;
-  layerMouseUp: EventEmitter<MapLayerMouseEvent & EventData>;
-  layerMouseEnter: EventEmitter<MapLayerMouseEvent & EventData>;
-  layerMouseLeave: EventEmitter<MapLayerMouseEvent & EventData>;
-  layerMouseMove: EventEmitter<MapLayerMouseEvent & EventData>;
-  layerMouseOver: EventEmitter<MapLayerMouseEvent & EventData>;
-  layerMouseOut: EventEmitter<MapLayerMouseEvent & EventData>;
-  layerContextMenu: EventEmitter<MapLayerMouseEvent & EventData>;
-  layerTouchStart: EventEmitter<MapLayerTouchEvent & EventData>;
-  layerTouchEnd: EventEmitter<MapLayerTouchEvent & EventData>;
-  layerTouchCancel: EventEmitter<MapLayerTouchEvent & EventData>;
+  layerClick: OutputEmitterRef<MapLayerMouseEvent & EventData>;
+  layerDblClick: OutputEmitterRef<MapLayerMouseEvent & EventData>;
+  layerMouseDown: OutputEmitterRef<MapLayerMouseEvent & EventData>;
+  layerMouseUp: OutputEmitterRef<MapLayerMouseEvent & EventData>;
+  layerMouseEnter: OutputEmitterRef<MapLayerMouseEvent & EventData>;
+  layerMouseLeave: OutputEmitterRef<MapLayerMouseEvent & EventData>;
+  layerMouseMove: OutputEmitterRef<MapLayerMouseEvent & EventData>;
+  layerMouseOver: OutputEmitterRef<MapLayerMouseEvent & EventData>;
+  layerMouseOut: OutputEmitterRef<MapLayerMouseEvent & EventData>;
+  layerContextMenu: OutputEmitterRef<MapLayerMouseEvent & EventData>;
+  layerTouchStart: OutputEmitterRef<MapLayerTouchEvent & EventData>;
+  layerTouchEnd: OutputEmitterRef<MapLayerTouchEvent & EventData>;
+  layerTouchCancel: OutputEmitterRef<MapLayerTouchEvent & EventData>;
 }
 
 /**

--- a/projects/ngx-maplibre-gl/src/lib/marker/marker.component.spec.ts
+++ b/projects/ngx-maplibre-gl/src/lib/marker/marker.component.spec.ts
@@ -5,6 +5,17 @@ import { of } from 'rxjs';
 import { MapService } from '../map/map.service';
 import { MarkerComponent } from './marker.component';
 
+const getMapServiceStub = () =>
+  jasmine.createSpyObj(
+    [
+      'addMarker',
+      'removeMarker',
+    ],
+    {
+      mapCreated$: of(true),
+    }
+  );
+
 @Component({
   template: `
     <mgl-marker [offset]="offset" [lngLat]="lngLat" [className]="className">
@@ -21,23 +32,19 @@ class MarkerTestComponent {
 }
 
 describe('MarkerComponent', () => {
-  class MapServiceSpy {
-    addMarker = jasmine.createSpy('addMarker');
-    removeMarker = jasmine.createSpy('removeMarker');
-    mapCreated$ = of(undefined);
-  }
-
-  let msSpy: MapServiceSpy;
+  let mapServiceStub: jasmine.SpyObj<MapService>;
   let component: MarkerTestComponent;
   let fixture: ComponentFixture<MarkerTestComponent>;
 
   beforeEach(waitForAsync(() => {
+    mapServiceStub = getMapServiceStub();
+
     TestBed.configureTestingModule({
       imports: [MarkerTestComponent],
     })
       .overrideComponent(MarkerTestComponent, {
         set: {
-          providers: [{ provide: MapService, useClass: MapServiceSpy }],
+          providers: [{ provide: MapService, useValue: mapServiceStub }],
         },
       })
       .compileComponents();
@@ -46,19 +53,18 @@ describe('MarkerComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(MarkerTestComponent);
     component = fixture.componentInstance;
-    msSpy = fixture.debugElement.injector.get<MapService>(MapService) as any;
   });
 
   describe('Init/Destroy tests', () => {
     it('should init with custom inputs', () => {
       component.lngLat = [-61, -15];
       fixture.detectChanges();
-      expect(msSpy.addMarker).toHaveBeenCalled();
+      expect(mapServiceStub.addMarker).toHaveBeenCalled();
     });
 
     it('should remove marker on destroy', () => {
       fixture.destroy();
-      expect(msSpy.removeMarker).toHaveBeenCalled();
+      expect(mapServiceStub.removeMarker).toHaveBeenCalled();
     });
 
     it('should apply classes', () => {

--- a/projects/ngx-maplibre-gl/src/lib/marker/marker.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/marker/marker.component.ts
@@ -46,15 +46,16 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
   standalone: true,
 })
 export class MarkerComponent implements OnChanges, OnInit {
-  /* Init injection */
+  /** Init injection */
   private readonly mapService = inject(MapService);
   private readonly destroyRef = inject(DestroyRef);
 
-  /* Init input */
+  /** Init inputs */
   readonly offset = input<MarkerOptions['offset']>();
   readonly anchor = input<MarkerOptions['anchor']>();
   readonly clickTolerance = input<MarkerOptions['clickTolerance']>();
   readonly color = input<MarkerOptions['color']>();
+ /** Dynamic input */
   readonly feature = input<GeoJSON.Feature<GeoJSON.Point>>();
   readonly lngLat = input<LngLatLike>();
   readonly draggable = input<MarkerOptions['draggable']>();

--- a/projects/ngx-maplibre-gl/src/lib/marker/marker.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/marker/marker.component.ts
@@ -1,19 +1,20 @@
 import {
-  AfterViewInit,
   ChangeDetectionStrategy,
   Component,
   ElementRef,
-  Input,
   OnChanges,
   OnDestroy,
   OnInit,
   SimpleChanges,
   ViewEncapsulation,
+  afterRender,
   inject,
+  input,
   output,
+  signal,
   viewChild,
 } from '@angular/core';
-import { LngLatLike, Marker, MarkerOptions } from 'maplibre-gl';
+import type { LngLatLike, Marker, MarkerOptions } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
 
 /**
@@ -36,117 +37,120 @@ import { MapService } from '../map/map.service';
  */
 @Component({
   selector: 'mgl-marker',
-  template: '<div [class]="className" #content><ng-content></ng-content></div>',
+  template: '<div [class]="className()" #content><ng-content></ng-content></div>',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
 })
-export class MarkerComponent
-  implements OnChanges, OnDestroy, AfterViewInit, OnInit
-{
+export class MarkerComponent implements OnChanges, OnDestroy, OnInit {
   /* Init injection */
   private readonly mapService = inject(MapService);
 
   /* Init input */
-  @Input() offset?: MarkerOptions['offset'];
-  @Input() anchor?: MarkerOptions['anchor'];
-  @Input() clickTolerance?: MarkerOptions['clickTolerance'];
-  @Input() color?: MarkerOptions['color'];
+  readonly offset = input<MarkerOptions['offset']>();
+  readonly anchor = input<MarkerOptions['anchor']>();
+  readonly clickTolerance = input<MarkerOptions['clickTolerance']>();
+  readonly color = input<MarkerOptions['color']>();
 
   /* Dynamic input */
-  @Input() feature?: GeoJSON.Feature<GeoJSON.Point>;
-  @Input() lngLat?: LngLatLike;
-  @Input() draggable?: MarkerOptions['draggable'];
-  @Input() popupShown?: boolean;
-  @Input() className: string;
-  @Input() pitchAlignment?: MarkerOptions['pitchAlignment'];
-  @Input() rotationAlignment?: MarkerOptions['rotationAlignment'];
-  @Input() rotation?: MarkerOptions['rotation'];
+  readonly feature = input<GeoJSON.Feature<GeoJSON.Point>>();
+  readonly lngLat = input<LngLatLike>();
+  readonly draggable = input<MarkerOptions['draggable']>();
+  readonly popupShown = input<boolean>();
+  readonly className = input<string>();
+  readonly pitchAlignment = input<MarkerOptions['pitchAlignment']>();
+  readonly rotationAlignment = input<MarkerOptions['rotationAlignment']>();
+  readonly rotation = input<MarkerOptions['rotation']>();
 
   readonly markerDragStart = output<Marker>();
   readonly markerDragEnd = output<Marker>();
   readonly markerDrag = output<Marker>();
 
-  readonly content = viewChild.required<ElementRef>('content');
+  readonly content = viewChild.required<string, ElementRef>('content', {
+    read: ElementRef,
+  });
 
-  markerInstance?: Marker;
+  readonly markerInstance = signal<Marker | null>(null);
+
+  constructor() {
+    afterRender(() => {
+      this.mapService.mapCreated$.subscribe(() => {
+        const marker = this.mapService.addMarker({
+          markersOptions: {
+            offset: this.offset(),
+            anchor: this.anchor(),
+            color: this.color(),
+            pitchAlignment: this.pitchAlignment(),
+            rotationAlignment: this.rotationAlignment(),
+            rotation: this.rotation(),
+            draggable: !!this.draggable(),
+            element: this.content().nativeElement,
+            feature: this.feature(),
+            lngLat: this.lngLat(),
+            clickTolerance: this.clickTolerance(),
+          },
+          markersEvents: {
+            markerDragStart: this.markerDragStart,
+            markerDrag: this.markerDrag,
+            markerDragEnd: this.markerDragEnd,
+          },
+        });
+        this.markerInstance.set(marker);
+      });
+    });
+  }
 
   ngOnInit() {
-    if (this.feature && this.lngLat) {
+    if (this.feature() && this.lngLat()) {
       throw new Error('feature and lngLat input are mutually exclusive');
     }
   }
 
   ngOnChanges(changes: SimpleChanges) {
+    const markerInstance = this.markerInstance()!;
     if (changes.lngLat && !changes.lngLat.isFirstChange()) {
-      this.markerInstance!.setLngLat(this.lngLat!);
+      markerInstance.setLngLat(changes.lngLat.currentValue);
     }
+
     if (changes.feature && !changes.feature.isFirstChange()) {
-      this.markerInstance!.setLngLat(
-        <[number, number]>this.feature!.geometry!.coordinates
+      markerInstance.setLngLat(
+        <[number, number]>changes.feature.currentValue.geometry.coordinates
       );
     }
     if (changes.draggable && !changes.draggable.isFirstChange()) {
-      this.markerInstance!.setDraggable(!!this.draggable);
+      markerInstance.setDraggable(!!changes.draggable.currentValue);
     }
     if (changes.popupShown && !changes.popupShown.isFirstChange()) {
       changes.popupShown.currentValue
-        ? this.markerInstance!.getPopup().addTo(this.mapService.mapInstance)
-        : this.markerInstance!.getPopup().remove();
+        ? markerInstance.getPopup().addTo(this.mapService.mapInstance)
+        : markerInstance.getPopup().remove();
     }
     if (changes.pitchAlignment && !changes.pitchAlignment.isFirstChange()) {
-      this.markerInstance!.setPitchAlignment(
-        changes.pitchAlignment.currentValue
-      );
+      markerInstance.setPitchAlignment(changes.pitchAlignment.currentValue);
     }
     if (
       changes.rotationAlignment &&
       !changes.rotationAlignment.isFirstChange()
     ) {
-      this.markerInstance!.setRotationAlignment(
+      markerInstance.setRotationAlignment(
         changes.rotationAlignment.currentValue
       );
     }
     if (changes.rotation && !changes.rotation.isFirstChange()) {
-      this.markerInstance!.setRotation(changes.rotation.currentValue);
+      markerInstance.setRotation(changes.rotation.currentValue);
     }
   }
 
-  ngAfterViewInit() {
-    this.mapService.mapCreated$.subscribe(() => {
-      this.markerInstance = this.mapService.addMarker({
-        markersOptions: {
-          offset: this.offset,
-          anchor: this.anchor,
-          color: this.color,
-          pitchAlignment: this.pitchAlignment,
-          rotationAlignment: this.rotationAlignment,
-          rotation: this.rotation,
-          draggable: !!this.draggable,
-          element: this.content().nativeElement,
-          feature: this.feature,
-          lngLat: this.lngLat,
-          clickTolerance: this.clickTolerance,
-        },
-        markersEvents: {
-          markerDragStart: this.markerDragStart,
-          markerDrag: this.markerDrag,
-          markerDragEnd: this.markerDragEnd,
-        },
-      });
-    });
-  }
-
   ngOnDestroy() {
-    this.mapService.removeMarker(this.markerInstance!);
-    this.markerInstance = undefined;
+    this.mapService.removeMarker(this.markerInstance()!);
+    this.markerInstance.set(null);
   }
 
   togglePopup() {
-    this.markerInstance!.togglePopup();
+    this.markerInstance()!.togglePopup();
   }
 
   updateCoordinates(coordinates: number[]) {
-    this.markerInstance!.setLngLat(<[number, number]>coordinates);
+    this.markerInstance()!.setLngLat(<[number, number]>coordinates);
   }
 }

--- a/projects/ngx-maplibre-gl/src/lib/marker/marker.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/marker/marker.component.ts
@@ -3,15 +3,15 @@ import {
   ChangeDetectionStrategy,
   Component,
   ElementRef,
-  EventEmitter,
   Input,
   OnChanges,
   OnDestroy,
   OnInit,
-  Output,
   SimpleChanges,
-  ViewChild,
   ViewEncapsulation,
+  inject,
+  output,
+  viewChild,
 } from '@angular/core';
 import { LngLatLike, Marker, MarkerOptions } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
@@ -19,9 +19,9 @@ import { MapService } from '../map/map.service';
 /**
  * `mgl-marker` - a marker component
  * @see [Marker](https://maplibre.org/maplibre-gl-js/docs/API/classes/Marker/)
- * 
+ *
  * @category Components
- * 
+ *
  * @example
  * ```html
  * ...
@@ -31,7 +31,7 @@ import { MapService } from '../map/map.service';
  *   </mgl-marker>
  * </mgl-map>
  * ```
- * 
+ *
  * Note: Only use this if you **really** need to use HTML/Angular component to render your symbol. These markers are slow compared to a `Layer` of symbol because they're not rendered using WebGL.
  */
 @Component({
@@ -42,7 +42,11 @@ import { MapService } from '../map/map.service';
   standalone: true,
 })
 export class MarkerComponent
-  implements OnChanges, OnDestroy, AfterViewInit, OnInit {
+  implements OnChanges, OnDestroy, AfterViewInit, OnInit
+{
+  /* Init injection */
+  private readonly mapService = inject(MapService);
+
   /* Init input */
   @Input() offset?: MarkerOptions['offset'];
   @Input() anchor?: MarkerOptions['anchor'];
@@ -59,15 +63,13 @@ export class MarkerComponent
   @Input() rotationAlignment?: MarkerOptions['rotationAlignment'];
   @Input() rotation?: MarkerOptions['rotation'];
 
-  @Output() markerDragStart = new EventEmitter<Marker>();
-  @Output() markerDragEnd = new EventEmitter<Marker>();
-  @Output() markerDrag = new EventEmitter<Marker>();
+  readonly markerDragStart = output<Marker>();
+  readonly markerDragEnd = output<Marker>();
+  readonly markerDrag = output<Marker>();
 
-  @ViewChild('content', { static: true }) content: ElementRef;
+  readonly content = viewChild.required<ElementRef>('content');
 
   markerInstance?: Marker;
-
-  constructor(private mapService: MapService) {}
 
   ngOnInit() {
     if (this.feature && this.lngLat) {
@@ -105,13 +107,8 @@ export class MarkerComponent
         changes.rotationAlignment.currentValue
       );
     }
-    if (
-      changes.rotation &&
-      !changes.rotation.isFirstChange()
-    ) {
-      this.markerInstance!.setRotation(
-        changes.rotation.currentValue
-      );
+    if (changes.rotation && !changes.rotation.isFirstChange()) {
+      this.markerInstance!.setRotation(changes.rotation.currentValue);
     }
   }
 
@@ -126,7 +123,7 @@ export class MarkerComponent
           rotationAlignment: this.rotationAlignment,
           rotation: this.rotation,
           draggable: !!this.draggable,
-          element: this.content.nativeElement,
+          element: this.content().nativeElement,
           feature: this.feature,
           lngLat: this.lngLat,
           clickTolerance: this.clickTolerance,

--- a/projects/ngx-maplibre-gl/src/lib/markers-for-clusters/markers-for-clusters.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/markers-for-clusters/markers-for-clusters.component.ts
@@ -1,6 +1,5 @@
 import {
   ChangeDetectionStrategy,
-  ChangeDetectorRef,
   Component,
   DestroyRef,
   Directive,
@@ -77,7 +76,7 @@ let uniqId = 0;
   template: `
     <mgl-layer
       [id]="layerId"
-      [source]="source"
+      [source]="source()"
       type="circle"
       [paint]="{ 'circle-radius': 0 }"
     ></mgl-layer>
@@ -104,16 +103,23 @@ let uniqId = 0;
 export class MarkersForClustersComponent {
   private readonly destroyRef = inject(DestroyRef);
   private readonly mapService = inject(MapService);
-  private readonly changeDetectorRef = inject(ChangeDetectorRef);
   private readonly ngZone = inject(NgZone);
 
   /** Init input */
   readonly source = input.required<string>();
 
   /** @hidden */
-  readonly pointTpl = contentChild(PointDirective, { read: TemplateRef });
+  readonly pointTpl = contentChild<PointDirective, TemplateRef<PointDirective>>(
+    PointDirective,
+    {
+      read: TemplateRef,
+    }
+  );
   /** @hidden */
-  readonly clusterPointTpl = contentChild(ClusterPointDirective, {
+  readonly clusterPointTpl = contentChild<
+    ClusterPointDirective,
+    TemplateRef<ClusterPointDirective>
+  >(ClusterPointDirective, {
     read: TemplateRef,
   });
 
@@ -157,11 +163,10 @@ export class MarkersForClustersComponent {
     this.clusterPoints.set(
       this.mapService.mapInstance.queryRenderedFeatures(params)
     );
-    this.changeDetectorRef.markForCheck();
   }
 
   getClusterParams(
-    pointTpl: TemplateRef<any> | undefined
+    pointTpl: TemplateRef<PointDirective> | undefined
   ): QueryRenderedFeaturesOptions {
     if (!pointTpl) {
       return { layers: [this.layerId], filter: ['==', 'cluster', true] };

--- a/projects/ngx-maplibre-gl/src/lib/ngx-maplibre-gl.module.ts
+++ b/projects/ngx-maplibre-gl/src/lib/ngx-maplibre-gl.module.ts
@@ -25,6 +25,7 @@ import { RasterDemSourceComponent } from './source/raster-dem-source.component';
 import { RasterSourceComponent } from './source/raster-source.component';
 import { VectorSourceComponent } from './source/vector-source.component';
 import { VideoSourceComponent } from './source/video-source.component';
+import { SourceDirective } from './source/source.directive';
 
 const componentsAndDirectives = [
   MapComponent,
@@ -51,6 +52,7 @@ const componentsAndDirectives = [
   ClusterPointDirective,
   MarkersForClustersComponent,
   TerrainControlDirective,
+  SourceDirective
 ];
 
 @NgModule({

--- a/projects/ngx-maplibre-gl/src/lib/popup/popup.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/popup/popup.component.ts
@@ -2,15 +2,15 @@ import {
   ChangeDetectionStrategy,
   Component,
   ElementRef,
-  EventEmitter,
   Input,
   OnChanges,
   OnDestroy,
   OnInit,
-  Output,
   SimpleChanges,
-  ViewChild,
   afterNextRender,
+  inject,
+  output,
+  viewChild,
 } from '@angular/core';
 import { LngLatLike, Offset, Popup, PopupOptions } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
@@ -42,6 +42,9 @@ import { MarkerComponent } from '../marker/marker.component';
   standalone: true,
 })
 export class PopupComponent implements OnChanges, OnDestroy, OnInit {
+  /** Init injection */
+  private readonly mapService = inject(MapService);
+
   /** Init input */
   @Input() closeButton?: PopupOptions['closeButton'];
   /** Init input */
@@ -72,15 +75,15 @@ export class PopupComponent implements OnChanges, OnDestroy, OnInit {
   /** Dynamic input */
   @Input() offset?: Offset;
 
-  @Output() popupClose = new EventEmitter<void>();
-  @Output() popupOpen = new EventEmitter<void>();
+  readonly popupClose = output<void>();
+  readonly popupOpen = output<void>();
 
   /** @hidden */
-  @ViewChild('content', { static: true }) content: ElementRef;
+  readonly content = viewChild.required<ElementRef>('content');
 
   popupInstance?: maplibregl.Popup;
 
-  constructor(private mapService: MapService) {
+  constructor() {
     afterNextRender(() => {
       this.popupInstance = this.createPopup();
       this.addPopup(this.popupInstance as Popup);
@@ -166,7 +169,7 @@ export class PopupComponent implements OnChanges, OnDestroy, OnInit {
           popupClose: this.popupClose,
         },
       },
-      this.content.nativeElement
+      this.content().nativeElement
     );
   }
 

--- a/projects/ngx-maplibre-gl/src/lib/popup/popup.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/popup/popup.component.ts
@@ -58,15 +58,21 @@ export class PopupComponent implements OnChanges, OnInit {
   readonly maxWidth = input<PopupOptions['maxWidth']>();
 
   /**
+   * Dynamic input [ngx]
    * Mutually exclusive with `lngLat`
    */
   readonly feature = input<GeoJSON.Feature<GeoJSON.Point>>();
+
+  /** Dynamic input */
   readonly lngLat = input<LngLatLike>();
+
   /**
+   * Dynamic input [ngx]
    * The targeted marker
    */
   readonly marker = input<MarkerComponent>();
 
+  /** Dynamic input */
   readonly offset = input<Offset>();
 
   readonly popupClose = output<void>();

--- a/projects/ngx-maplibre-gl/src/lib/popup/popup.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/popup/popup.component.ts
@@ -50,11 +50,23 @@ export class PopupComponent implements OnChanges, OnInit {
 
   /** Init input */
   readonly closeButton = input<PopupOptions['closeButton']>();
+
+  /** Init input */
   readonly closeOnClick = input<PopupOptions['closeOnClick']>();
+
+  /** Init input */
   readonly closeOnMove = input<PopupOptions['closeOnMove']>();
+
+  /** Init input */
   readonly focusAfterOpen = input<PopupOptions['focusAfterOpen']>();
+
+  /** Init input */
   readonly anchor = input<PopupOptions['anchor']>();
+
+  /** Init input */
   readonly className = input<PopupOptions['className']>();
+
+  /** Init input */
   readonly maxWidth = input<PopupOptions['maxWidth']>();
 
   /**

--- a/projects/ngx-maplibre-gl/src/lib/shared/index.ts
+++ b/projects/ngx-maplibre-gl/src/lib/shared/index.ts
@@ -1,0 +1,1 @@
+export * from './utils';

--- a/projects/ngx-maplibre-gl/src/lib/shared/index.ts
+++ b/projects/ngx-maplibre-gl/src/lib/shared/index.ts
@@ -1,1 +1,0 @@
-export * from './utils';

--- a/projects/ngx-maplibre-gl/src/lib/shared/utils/functions/index.ts
+++ b/projects/ngx-maplibre-gl/src/lib/shared/utils/functions/index.ts
@@ -1,0 +1,1 @@
+export * from './object.fn';

--- a/projects/ngx-maplibre-gl/src/lib/shared/utils/functions/index.ts
+++ b/projects/ngx-maplibre-gl/src/lib/shared/utils/functions/index.ts
@@ -1,1 +1,0 @@
-export * from './object.fn';

--- a/projects/ngx-maplibre-gl/src/lib/shared/utils/functions/object.fn.ts
+++ b/projects/ngx-maplibre-gl/src/lib/shared/utils/functions/object.fn.ts
@@ -1,0 +1,9 @@
+export const keepAvailableObjectValues = <T extends {}>(object: T): Required<T> => {
+  return Object.keys(object).reduce((acc, curr) => {
+    const tKey = curr as keyof T;
+    if (object[tKey] === undefined) {
+      return acc;
+    }
+    return { ...acc, [tKey]: object[tKey] };
+  }, {} as Required<T>);
+};

--- a/projects/ngx-maplibre-gl/src/lib/shared/utils/index.ts
+++ b/projects/ngx-maplibre-gl/src/lib/shared/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './functions';

--- a/projects/ngx-maplibre-gl/src/lib/shared/utils/index.ts
+++ b/projects/ngx-maplibre-gl/src/lib/shared/utils/index.ts
@@ -1,1 +1,0 @@
-export * from './functions';

--- a/projects/ngx-maplibre-gl/src/lib/source/base-source.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/base-source.directive.ts
@@ -1,0 +1,65 @@
+import {
+  DestroyRef,
+  Directive,
+  OnInit,
+  inject,
+  input,
+  signal,
+} from '@angular/core';
+import { Subject, fromEvent } from 'rxjs';
+import { filter, switchMap, tap } from 'rxjs/operators';
+import { MapService } from '../map/map.service';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+
+/**
+ * `mgl-canvas-source` - a canvas source component
+ * @see [canvas](https://maplibre.org/maplibre-style-spec/sources/#canvas)
+ *
+ * @category Source Components
+ */
+@Directive({
+  standalone: true,
+})
+export class BaseSourceDirective implements OnInit {
+  /** Init injection */
+  readonly mapService = inject(MapService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  /**  Init input */
+  readonly id = input.required<string>();
+  readonly sourceId = signal<string | null>(null);
+
+  private readonly loadSourceSubject = new Subject<void>();
+  readonly loadSource$ = this.loadSourceSubject.asObservable();
+
+  constructor() {
+    this.destroyRef.onDestroy(() => this.removeSource.bind(this));
+  }
+
+  ngOnInit() {
+    this.mapService.mapLoaded$
+      .pipe(
+        tap(() => this.loadSourceSubject.next()),
+        switchMap(() =>
+          fromEvent(this.mapService.mapInstance, 'styledata').pipe(
+            filter(() => !this.mapService.mapInstance.getSource(this.id())),
+            tap(() => this.loadSourceSubject.next())
+          )
+        ),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe();
+  }
+
+  refresh() {
+    this.removeSource();
+    this.loadSourceSubject.next();
+  }
+
+  removeSource() {
+    if (this.sourceId()) {
+      this.mapService.removeSource(this.id());
+      this.sourceId.set(null);
+    }
+  }
+}

--- a/projects/ngx-maplibre-gl/src/lib/source/canvas-source.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/canvas-source.component.ts
@@ -6,6 +6,7 @@ import {
   OnDestroy,
   OnInit,
   SimpleChanges,
+  inject,
 } from '@angular/core';
 import { CanvasSource, CanvasSourceSpecification } from 'maplibre-gl';
 import { fromEvent, Subscription } from 'rxjs';
@@ -15,7 +16,7 @@ import { MapService } from '../map/map.service';
 /**
  * `mgl-canvas-source` - a canvas source component
  * @see [canvas](https://maplibre.org/maplibre-style-spec/sources/#canvas)
- * 
+ *
  * @category Source Components
  */
 @Component({
@@ -25,7 +26,10 @@ import { MapService } from '../map/map.service';
   standalone: true,
 })
 export class CanvasSourceComponent
-  implements OnInit, OnDestroy, OnChanges, CanvasSourceSpecification {
+  implements OnInit, OnDestroy, OnChanges, CanvasSourceSpecification
+{
+  /** Init injection */
+  private readonly mapService = inject(MapService);
   /**  Init input */
   @Input() id: string;
 
@@ -39,8 +43,6 @@ export class CanvasSourceComponent
   type: CanvasSourceSpecification['type'] = 'canvas';
   private sourceAdded = false;
   private sub = new Subscription();
-
-  constructor(private mapService: MapService) {}
 
   ngOnInit() {
     const sub1 = this.mapService.mapLoaded$.subscribe(() => {

--- a/projects/ngx-maplibre-gl/src/lib/source/geojson/feature.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/geojson/feature.component.ts
@@ -22,7 +22,6 @@ import { GeoJSONSourceComponent } from './geojson-source.component';
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
 })
-// GeoJSON.Feature<GeoJSON.GeometryObject>
 export class FeatureComponent implements OnInit, OnDestroy {
   /** Init injection */
   private readonly geoJSONSourceComponent = inject<GeoJSONSourceComponent>(
@@ -31,9 +30,7 @@ export class FeatureComponent implements OnInit, OnDestroy {
   /** Init input */
   readonly id = model<number>(); // FIXME number only for now https://github.com/mapbox/mapbox-gl-js/issues/2716
   readonly geometry = input.required<GeoJSON.GeometryObject>();
-  readonly properties = input<any>();
-
-  readonly type: 'Feature' = 'Feature';
+  readonly properties = input<GeoJSON.Feature<GeoJSON.GeometryObject>['properties']>();
 
   private feature: GeoJSON.Feature<GeoJSON.GeometryObject>;
 
@@ -42,10 +39,11 @@ export class FeatureComponent implements OnInit, OnDestroy {
     if (!id) {
       this.id.set(this.geoJSONSourceComponent._getNewFeatureId());
     }
+    const properties = this.properties();
     this.feature = {
-      type: this.type,
+      type: 'Feature',
       geometry: this.geometry(),
-      properties: this.properties ? this.properties : {},
+      properties: properties ?? {},
     };
     this.feature.id = this.id();
     this.geoJSONSourceComponent._addFeature(this.feature);

--- a/projects/ngx-maplibre-gl/src/lib/source/geojson/feature.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/geojson/feature.component.ts
@@ -29,7 +29,11 @@ export class FeatureComponent implements OnInit, OnDestroy {
   );
   /** Init input */
   readonly id = model<number>(); // FIXME number only for now https://github.com/mapbox/mapbox-gl-js/issues/2716
+ 
+  /** Init input */
   readonly geometry = input.required<GeoJSON.GeometryObject>();
+  
+  /** Init input */
   readonly properties = input<GeoJSON.Feature<GeoJSON.GeometryObject>['properties']>();
 
   private feature: GeoJSON.Feature<GeoJSON.GeometryObject>;
@@ -55,6 +59,6 @@ export class FeatureComponent implements OnInit, OnDestroy {
 
   updateCoordinates(coordinates: number[]) {
     (<GeoJSON.Point>this.feature.geometry).coordinates = coordinates;
-    this.geoJSONSourceComponent.updateFeatureData.next(undefined);
+    this.geoJSONSourceComponent.updateFeatureData();
   }
 }

--- a/projects/ngx-maplibre-gl/src/lib/source/geojson/feature.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/geojson/feature.component.ts
@@ -28,8 +28,7 @@ export class FeatureComponent implements OnInit, OnDestroy {
     forwardRef(() => GeoJSONSourceComponent)
   );
   /** Init input */
-  readonly id = model<number>(); // FIXME number only for now https://github.com/mapbox/mapbox-gl-js/issues/2716
- 
+  readonly id = model<number>(); 
   /** Init input */
   readonly geometry = input.required<GeoJSON.GeometryObject>();
   

--- a/projects/ngx-maplibre-gl/src/lib/source/geojson/feature.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/geojson/feature.component.ts
@@ -1,53 +1,53 @@
 import {
   Component,
   forwardRef,
-  Inject,
-  Input,
   OnDestroy,
   OnInit,
   ChangeDetectionStrategy,
+  input,
+  model,
+  inject,
 } from '@angular/core';
 import { GeoJSONSourceComponent } from './geojson-source.component';
 
 /**
  * `mgl-feature` - a feature component
  * [ngx] inside {@link GeoJSONSourceComponent} only
- * 
+ *
  * @category Source Components
  */
 @Component({
-    selector: 'mgl-feature',
-    template: '',
-    changeDetection: ChangeDetectionStrategy.OnPush,
-    standalone: true,
+  selector: 'mgl-feature',
+  template: '',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
 })
-export class FeatureComponent
-  implements OnInit, OnDestroy, GeoJSON.Feature<GeoJSON.GeometryObject> {
+// GeoJSON.Feature<GeoJSON.GeometryObject>
+export class FeatureComponent implements OnInit, OnDestroy {
+  /** Init injection */
+  private readonly geoJSONSourceComponent = inject<GeoJSONSourceComponent>(
+    forwardRef(() => GeoJSONSourceComponent)
+  );
   /** Init input */
-  @Input() id?: number; // FIXME number only for now https://github.com/mapbox/mapbox-gl-js/issues/2716
-  /** Init input */
-  @Input() geometry: GeoJSON.GeometryObject;
-  /** Init input */
-  @Input() properties: any;
-  type: 'Feature' = 'Feature';
+  readonly id = model<number>(); // FIXME number only for now https://github.com/mapbox/mapbox-gl-js/issues/2716
+  readonly geometry = input.required<GeoJSON.GeometryObject>();
+  readonly properties = input<any>();
+
+  readonly type: 'Feature' = 'Feature';
 
   private feature: GeoJSON.Feature<GeoJSON.GeometryObject>;
 
-  constructor(
-    @Inject(forwardRef(() => GeoJSONSourceComponent))
-    private geoJSONSourceComponent: GeoJSONSourceComponent
-  ) {}
-
   ngOnInit() {
-    if (!this.id) {
-      this.id = this.geoJSONSourceComponent._getNewFeatureId();
+    const id = this.id();
+    if (!id) {
+      this.id.set(this.geoJSONSourceComponent._getNewFeatureId());
     }
     this.feature = {
       type: this.type,
-      geometry: this.geometry,
+      geometry: this.geometry(),
       properties: this.properties ? this.properties : {},
     };
-    this.feature.id = this.id;
+    this.feature.id = this.id();
     this.geoJSONSourceComponent._addFeature(this.feature);
   }
 

--- a/projects/ngx-maplibre-gl/src/lib/source/geojson/geojson-source.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/geojson/geojson-source.component.ts
@@ -57,8 +57,6 @@ export class GeoJSONSourceComponent implements OnInit, OnDestroy, OnChanges {
 
   /** Init input */
   readonly id = input.required<string>();
-
-  /** Dynamic input */
   readonly data = input<GeoJSONSourceSpecification['data']>({
     type: 'FeatureCollection',
     features: [],
@@ -79,9 +77,6 @@ export class GeoJSONSourceComponent implements OnInit, OnDestroy, OnChanges {
   readonly generateId = input<GeoJSONSourceSpecification['generateId']>();
   readonly promoteId = input<GeoJSONSourceSpecification['promoteId']>();
   readonly filter = input<GeoJSONSourceSpecification['filter']>();
-
-  /** @hidden */
-  readonly type: GeoJSONSourceSpecification['type'] = 'geojson';
 
   readonly updateFeatureData = new Subject();
 

--- a/projects/ngx-maplibre-gl/src/lib/source/geojson/geojson-source.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/geojson/geojson-source.component.ts
@@ -7,6 +7,7 @@ import {
   OnInit,
   SimpleChanges,
   NgZone,
+  inject,
 } from '@angular/core';
 import { GeoJSONSource, GeoJSONSourceSpecification } from 'maplibre-gl';
 import { fromEvent, Subject, Subscription } from 'rxjs';
@@ -14,11 +15,11 @@ import { debounceTime, filter } from 'rxjs/operators';
 import { MapService } from '../../map/map.service';
 
 /**
- * `mgl-geojson-source` - a geojson source component 
+ * `mgl-geojson-source` - a geojson source component
  * @see [geojson](https://maplibre.org/maplibre-gl-js/docs/API/classes/maplibregl.GeoJSONSource/)
- * 
+ *
  * @category Source Components
- * 
+ *
  * @example
  * ```html
  * ...
@@ -38,17 +39,22 @@ import { MapService } from '../../map/map.service';
  *     [clusterRadius]="50"
  *   ></mgl-geojson-source>
  * </mgl-map>
- * 
+ *
  * ```
  */
 @Component({
-    selector: 'mgl-geojson-source',
-    template: '',
-    changeDetection: ChangeDetectionStrategy.OnPush,
-    standalone: true,
+  selector: 'mgl-geojson-source',
+  template: '',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
 })
 export class GeoJSONSourceComponent
-  implements OnInit, OnDestroy, OnChanges, GeoJSONSourceSpecification {
+  implements OnInit, OnDestroy, OnChanges, GeoJSONSourceSpecification
+{
+  /** Init injection */
+  private readonly mapService = inject(MapService);
+  private readonly ngZone = inject(NgZone);
+
   /** Init input */
   @Input() id: string;
 
@@ -89,8 +95,6 @@ export class GeoJSONSourceComponent
   private sub = new Subscription();
   private sourceAdded = false;
   private featureIdCounter = 0;
-
-  constructor(private mapService: MapService, private zone: NgZone) {}
 
   ngOnInit() {
     if (!this.data) {
@@ -157,7 +161,7 @@ export class GeoJSONSourceComponent
    */
   async getClusterExpansionZoom(clusterId: number) {
     const source = this.mapService.getSource<GeoJSONSource>(this.id);
-    return this.zone.run(async () => {
+    return this.ngZone.run(async () => {
       return source.getClusterExpansionZoom(clusterId);
     });
   }
@@ -168,7 +172,7 @@ export class GeoJSONSourceComponent
    */
   async getClusterChildren(clusterId: number) {
     const source = this.mapService.getSource<GeoJSONSource>(this.id);
-    return this.zone.run(async () => {
+    return this.ngZone.run(async () => {
       return source.getClusterChildren(clusterId);
     });
   }
@@ -181,12 +185,8 @@ export class GeoJSONSourceComponent
    */
   async getClusterLeaves(clusterId: number, limit: number, offset: number) {
     const source = this.mapService.getSource<GeoJSONSource>(this.id);
-    return this.zone.run(async () => {
-      return source.getClusterLeaves(
-        clusterId,
-        limit,
-        offset,
-      );
+    return this.ngZone.run(async () => {
+      return source.getClusterLeaves(clusterId, limit, offset);
     });
   }
 

--- a/projects/ngx-maplibre-gl/src/lib/source/image-source.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/image-source.component.ts
@@ -31,8 +31,10 @@ export class ImageSourceComponent implements OnInit, OnDestroy, OnChanges {
   private readonly destroyRef = inject(DestroyRef);
   private readonly mapService = inject(MapService);
 
-  /* Init inputs */
+  /** Init inputs */
   readonly id = input.required<string>();
+
+  /** Dynamic inputs */
   readonly url = input.required<ImageSourceSpecification['url']>();
   readonly coordinates =
     input.required<ImageSourceSpecification['coordinates']>();
@@ -44,7 +46,7 @@ export class ImageSourceComponent implements OnInit, OnDestroy, OnChanges {
   ngOnInit() {
     this.mapService.mapLoaded$
       .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(() => this.init());
+      .subscribe(() => this.addSource());
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -71,7 +73,7 @@ export class ImageSourceComponent implements OnInit, OnDestroy, OnChanges {
     }
   }
 
-  private init() {
+  private addSource() {
     const imageSource: ImageSourceSpecification = {
       type: 'image',
       url: this.url(),

--- a/projects/ngx-maplibre-gl/src/lib/source/image-source.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/image-source.component.ts
@@ -6,6 +6,7 @@ import {
   OnDestroy,
   OnInit,
   SimpleChanges,
+  inject,
 } from '@angular/core';
 import { ImageSourceSpecification, ImageSource } from 'maplibre-gl';
 import { Subscription } from 'rxjs';
@@ -14,7 +15,7 @@ import { MapService } from '../map/map.service';
 /**
  * `mgl-image-source` - an image source component
  * @see [image](https://maplibre.org/maplibre-style-spec/sources/#image)
- * 
+ *
  * @category Source Components
  */
 @Component({
@@ -24,7 +25,11 @@ import { MapService } from '../map/map.service';
   standalone: true,
 })
 export class ImageSourceComponent
-  implements OnInit, OnDestroy, OnChanges, ImageSourceSpecification {
+  implements OnInit, OnDestroy, OnChanges, ImageSourceSpecification
+{
+  /** Init injection */
+  private readonly mapService = inject(MapService);
+
   /* Init inputs */
   @Input() id: string;
 
@@ -36,8 +41,6 @@ export class ImageSourceComponent
 
   private sub: Subscription;
   private sourceId?: string;
-
-  constructor(private mapService: MapService) {}
 
   ngOnInit() {
     this.sub = this.mapService.mapLoaded$.subscribe(() => this.init());

--- a/projects/ngx-maplibre-gl/src/lib/source/image-source.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/image-source.component.ts
@@ -26,7 +26,6 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
 })
-// ImageSourceSpecification
 export class ImageSourceComponent implements OnInit, OnDestroy, OnChanges {
   /** Init injection */
   private readonly destroyRef = inject(DestroyRef);
@@ -34,8 +33,6 @@ export class ImageSourceComponent implements OnInit, OnDestroy, OnChanges {
 
   /* Init inputs */
   readonly id = input.required<string>();
-
-  /* Dynamic inputs */
   readonly url = input.required<ImageSourceSpecification['url']>();
   readonly coordinates =
     input.required<ImageSourceSpecification['coordinates']>();
@@ -60,7 +57,7 @@ export class ImageSourceComponent implements OnInit, OnDestroy, OnChanges {
       return;
     }
     source.updateImage({
-      url: changes.url === undefined ? (undefined as any) : this.url,
+      url: changes.url === undefined ? (undefined as any) : this.url(),
       coordinates:
         changes.coordinates === undefined ? undefined : this.coordinates(),
     });

--- a/projects/ngx-maplibre-gl/src/lib/source/raster-dem-source.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/raster-dem-source.component.ts
@@ -6,6 +6,7 @@ import {
   OnDestroy,
   OnInit,
   SimpleChanges,
+  inject,
 } from '@angular/core';
 import { RasterDEMSourceSpecification } from 'maplibre-gl';
 import { fromEvent, Subscription } from 'rxjs';
@@ -15,7 +16,7 @@ import { MapService } from '../map/map.service';
 /**
  * `mgl-raster-dem-source` - a raster DEM source
  * @see [raster DEM](https://maplibre.org/maplibre-style-spec/sources/#raster-dem)
- * 
+ *
  * @category Source Components
  */
 @Component({
@@ -25,7 +26,11 @@ import { MapService } from '../map/map.service';
   standalone: true,
 })
 export class RasterDemSourceComponent
-  implements OnInit, OnDestroy, OnChanges, RasterDEMSourceSpecification {
+  implements OnInit, OnDestroy, OnChanges, RasterDEMSourceSpecification
+{
+  /** Init injection */
+  private readonly mapService = inject(MapService);
+
   /** Init input */
   @Input() id: string;
 
@@ -51,8 +56,6 @@ export class RasterDemSourceComponent
 
   private sourceAdded = false;
   private sub = new Subscription();
-
-  constructor(private mapService: MapService) {}
 
   ngOnInit() {
     const sub1 = this.mapService.mapLoaded$.subscribe(() => {

--- a/projects/ngx-maplibre-gl/src/lib/source/raster-dem-source.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/raster-dem-source.component.ts
@@ -1,14 +1,15 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  Input,
   OnChanges,
   OnDestroy,
   OnInit,
   SimpleChanges,
   inject,
+  input,
+  signal,
 } from '@angular/core';
-import { RasterDEMSourceSpecification } from 'maplibre-gl';
+import type { RasterDEMSourceSpecification } from 'maplibre-gl';
 import { fromEvent, Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import { MapService } from '../map/map.service';
@@ -25,43 +26,35 @@ import { MapService } from '../map/map.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
 })
-export class RasterDemSourceComponent
-  implements OnInit, OnDestroy, OnChanges, RasterDEMSourceSpecification
-{
+// RasterDEMSourceSpecification
+export class RasterDemSourceComponent implements OnInit, OnDestroy, OnChanges {
   /** Init injection */
   private readonly mapService = inject(MapService);
 
   /** Init input */
-  @Input() id: string;
+  readonly id = input.required<string>();
 
   /** Dynamic input */
-  @Input() url?: RasterDEMSourceSpecification['url'];
-  /** Dynamic input */
-  @Input() tiles?: RasterDEMSourceSpecification['tiles'];
-  /** Dynamic input */
-  @Input() bounds?: RasterDEMSourceSpecification['bounds'];
-  /** Dynamic input */
-  @Input() minzoom?: RasterDEMSourceSpecification['minzoom'];
-  /** Dynamic input */
-  @Input() maxzoom?: RasterDEMSourceSpecification['maxzoom'];
-  /** Dynamic input */
-  @Input() tileSize?: RasterDEMSourceSpecification['tileSize'];
-  /** Dynamic input */
-  @Input() attribution?: RasterDEMSourceSpecification['attribution'];
-  /** Dynamic input */
-  @Input() encoding?: RasterDEMSourceSpecification['encoding'];
+  readonly url = input<RasterDEMSourceSpecification['url']>();
+  readonly tiles = input<RasterDEMSourceSpecification['tiles']>();
+  readonly bounds = input<RasterDEMSourceSpecification['bounds']>();
+  readonly minzoom = input<RasterDEMSourceSpecification['minzoom']>();
+  readonly maxzoom = input<RasterDEMSourceSpecification['maxzoom']>();
+  readonly tileSize = input<RasterDEMSourceSpecification['tileSize']>();
+  readonly attribution = input<RasterDEMSourceSpecification['attribution']>();
+  readonly encoding = input<RasterDEMSourceSpecification['encoding']>();
 
   /** @hidden */
-  type: RasterDEMSourceSpecification['type'] = 'raster-dem';
+  readonly type: RasterDEMSourceSpecification['type'] = 'raster-dem';
 
-  private sourceAdded = false;
-  private sub = new Subscription();
+  private readonly sourceAdded = signal(false);
+  private readonly sub = new Subscription();
 
   ngOnInit() {
     const sub1 = this.mapService.mapLoaded$.subscribe(() => {
       this.init();
       const sub = fromEvent(this.mapService.mapInstance, 'styledata')
-        .pipe(filter(() => !this.mapService.mapInstance.getSource(this.id)))
+        .pipe(filter(() => !this.mapService.mapInstance.getSource(this.id())))
         .subscribe(() => {
           this.init();
         });
@@ -71,7 +64,7 @@ export class RasterDemSourceComponent
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (!this.sourceAdded) {
+    if (!this.sourceAdded()) {
       return;
     }
     if (
@@ -91,25 +84,25 @@ export class RasterDemSourceComponent
 
   ngOnDestroy() {
     this.sub.unsubscribe();
-    if (this.sourceAdded) {
-      this.mapService.removeSource(this.id);
-      this.sourceAdded = false;
+    if (this.sourceAdded()) {
+      this.mapService.removeSource(this.id());
+      this.sourceAdded.set(false);
     }
   }
 
   private init() {
     const source: RasterDEMSourceSpecification = {
       type: this.type,
-      url: this.url,
-      tiles: this.tiles,
-      bounds: this.bounds,
-      minzoom: this.minzoom,
-      maxzoom: this.maxzoom,
-      tileSize: this.tileSize,
-      attribution: this.attribution,
-      encoding: this.encoding,
+      url: this.url(),
+      tiles: this.tiles(),
+      bounds: this.bounds(),
+      minzoom: this.minzoom(),
+      maxzoom: this.maxzoom(),
+      tileSize: this.tileSize(),
+      attribution: this.attribution(),
+      encoding: this.encoding(),
     };
-    this.mapService.addSource(this.id, source);
-    this.sourceAdded = true;
+    this.mapService.addSource(this.id(), source);
+    this.sourceAdded.set(true);
   }
 }

--- a/projects/ngx-maplibre-gl/src/lib/source/raster-dem-source.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/raster-dem-source.component.ts
@@ -26,7 +26,6 @@ import { MapService } from '../map/map.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
 })
-// RasterDEMSourceSpecification
 export class RasterDemSourceComponent implements OnInit, OnDestroy, OnChanges {
   /** Init injection */
   private readonly mapService = inject(MapService);
@@ -34,7 +33,6 @@ export class RasterDemSourceComponent implements OnInit, OnDestroy, OnChanges {
   /** Init input */
   readonly id = input.required<string>();
 
-  /** Dynamic input */
   readonly url = input<RasterDEMSourceSpecification['url']>();
   readonly tiles = input<RasterDEMSourceSpecification['tiles']>();
   readonly bounds = input<RasterDEMSourceSpecification['bounds']>();

--- a/projects/ngx-maplibre-gl/src/lib/source/raster-source.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/raster-source.component.ts
@@ -6,6 +6,7 @@ import {
   OnDestroy,
   OnInit,
   SimpleChanges,
+  inject,
 } from '@angular/core';
 import { RasterSourceSpecification } from 'maplibre-gl';
 import { fromEvent, Subscription } from 'rxjs';
@@ -15,7 +16,7 @@ import { MapService } from '../map/map.service';
 /**
  * `mgl-raster-source` - a raster source component
  * @see [raster](https://maplibre.org/maplibre-style-spec/sources/#raster)
- * 
+ *
  * @category Source Components
  */
 @Component({
@@ -25,7 +26,11 @@ import { MapService } from '../map/map.service';
   standalone: true,
 })
 export class RasterSourceComponent
-  implements OnInit, OnDestroy, OnChanges, RasterSourceSpecification {
+  implements OnInit, OnDestroy, OnChanges, RasterSourceSpecification
+{
+  /** Init injection */
+  private readonly mapService = inject(MapService);
+
   /** Init input */
   @Input() id: string;
 
@@ -51,8 +56,6 @@ export class RasterSourceComponent
 
   private sourceAdded = false;
   private sub = new Subscription();
-
-  constructor(private mapService: MapService) {}
 
   ngOnInit() {
     const sub1 = this.mapService.mapLoaded$.subscribe(() => {

--- a/projects/ngx-maplibre-gl/src/lib/source/raster-source.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/raster-source.component.ts
@@ -26,15 +26,12 @@ import { MapService } from '../map/map.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
 })
-// RasterSourceSpecification
 export class RasterSourceComponent implements OnInit, OnDestroy, OnChanges {
   /** Init injection */
   private readonly mapService = inject(MapService);
 
   /** Init input */
   readonly id = input.required<string>();
-
-  /** Dynamic input */
   readonly url = input<RasterSourceSpecification['url']>();
   readonly tiles = input<RasterSourceSpecification['tiles']>();
   readonly bounds = input<RasterSourceSpecification['bounds']>();

--- a/projects/ngx-maplibre-gl/src/lib/source/source.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/source.directive.ts
@@ -10,17 +10,16 @@ import { Subject, fromEvent } from 'rxjs';
 import { filter, switchMap, tap } from 'rxjs/operators';
 import { MapService } from '../map/map.service';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Source, SourceSpecification } from 'maplibre-gl';
 
 /**
- * `mgl-canvas-source` - a canvas source component
- * @see [canvas](https://maplibre.org/maplibre-style-spec/sources/#canvas)
  *
  * @category Source Components
  */
 @Directive({
   standalone: true,
 })
-export class BaseSourceDirective implements OnInit {
+export class SourceDirective implements OnInit {
   /** Init injection */
   readonly mapService = inject(MapService);
   private readonly destroyRef = inject(DestroyRef);
@@ -61,5 +60,14 @@ export class BaseSourceDirective implements OnInit {
       this.mapService.removeSource(this.id());
       this.sourceId.set(null);
     }
+  }
+
+  addSource(source: SourceSpecification) {
+    this.mapService.addSource(this.id(), source);
+    this.sourceId.set(this.id());
+  }
+
+  getSource<T extends Source>(): T | undefined {
+    return this.mapService.getSource<T>(this.id());
   }
 }

--- a/projects/ngx-maplibre-gl/src/lib/source/vector-source.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/vector-source.component.ts
@@ -6,6 +6,7 @@ import {
   OnDestroy,
   OnInit,
   SimpleChanges,
+  inject,
 } from '@angular/core';
 import { VectorSourceSpecification, VectorTileSource } from 'maplibre-gl';
 import { fromEvent, Subscription } from 'rxjs';
@@ -15,7 +16,7 @@ import { MapService } from '../map/map.service';
 /**
  * `mgl-vector-source` - a vector source component
  * @see [vector](https://maplibre.org/maplibre-style-spec/sources/#vector)
- * 
+ *
  * @category Source Components
  */
 @Component({
@@ -25,7 +26,11 @@ import { MapService } from '../map/map.service';
   standalone: true,
 })
 export class VectorSourceComponent
-  implements OnInit, OnDestroy, OnChanges, VectorSourceSpecification {
+  implements OnInit, OnDestroy, OnChanges, VectorSourceSpecification
+{
+  /* Init injection */
+  private readonly mapService = inject(MapService);
+
   /* Init inputs */
   @Input() id: string;
 
@@ -43,8 +48,6 @@ export class VectorSourceComponent
 
   private sourceAdded = false;
   private sub = new Subscription();
-
-  constructor(private mapService: MapService) {}
 
   ngOnInit() {
     const sub1 = this.mapService.mapLoaded$.subscribe(() => {

--- a/projects/ngx-maplibre-gl/src/lib/source/vector-source.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/vector-source.component.ts
@@ -26,15 +26,12 @@ import { MapService } from '../map/map.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
 })
-// VectorSourceSpecification
 export class VectorSourceComponent implements OnInit, OnDestroy, OnChanges {
   /* Init injection */
   private readonly mapService = inject(MapService);
 
   /* Init inputs */
   readonly id = input.required<string>();
-
-  /* Dynamic inputs */
   readonly url = input<VectorSourceSpecification['url']>();
   readonly tiles = input<VectorSourceSpecification['tiles']>();
   readonly bounds = input<VectorSourceSpecification['bounds']>();

--- a/projects/ngx-maplibre-gl/src/lib/source/video-source.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/video-source.component.ts
@@ -1,14 +1,15 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  Input,
   OnChanges,
   OnDestroy,
   OnInit,
   SimpleChanges,
   inject,
+  input,
+  signal,
 } from '@angular/core';
-import { VideoSource, VideoSourceSpecification } from 'maplibre-gl';
+import type { VideoSource, VideoSourceSpecification } from 'maplibre-gl';
 import { fromEvent, Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import { MapService } from '../map/map.service';
@@ -25,31 +26,30 @@ import { MapService } from '../map/map.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
 })
-export class VideoSourceComponent
-  implements OnInit, OnDestroy, OnChanges, VideoSourceSpecification
-{
+// VideoSourceSpecification
+export class VideoSourceComponent implements OnInit, OnDestroy, OnChanges {
   /** Init injection */
   private readonly mapService = inject(MapService);
 
   /** Init input */
-  @Input() id: string;
+  readonly id = input.required<string>();
 
   /** Dynamic input */
-  @Input() urls: VideoSourceSpecification['urls'];
-  /** Dynamic input */
-  @Input() coordinates: VideoSourceSpecification['coordinates'];
+  readonly urls = input.required<VideoSourceSpecification['urls']>();
+  readonly coordinates =
+    input.required<VideoSourceSpecification['coordinates']>();
 
   /** @hidden */
-  type: VideoSourceSpecification['type'] = 'video';
+  readonly type: VideoSourceSpecification['type'] = 'video';
 
-  private sourceAdded = false;
+  private readonly sourceAdded = signal(false);
   private sub = new Subscription();
 
   ngOnInit() {
     const sub1 = this.mapService.mapLoaded$.subscribe(() => {
       this.init();
       const sub = fromEvent(this.mapService.mapInstance, 'styledata')
-        .pipe(filter(() => !this.mapService.mapInstance.getSource(this.id)))
+        .pipe(filter(() => !this.mapService.mapInstance.getSource(this.id())))
         .subscribe(() => {
           this.init();
         });
@@ -59,7 +59,7 @@ export class VideoSourceComponent
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (!this.sourceAdded) {
+    if (!this.sourceAdded()) {
       return;
     }
 
@@ -67,29 +67,29 @@ export class VideoSourceComponent
       this.ngOnDestroy();
       this.ngOnInit();
     } else if (changes.coordinates && !changes.coordinates.isFirstChange()) {
-      const source = this.mapService.getSource<VideoSource>(this.id);
+      const source = this.mapService.getSource<VideoSource>(this.id());
       if (source === undefined) {
         return;
       }
-      source.setCoordinates(this.coordinates!);
+      source.setCoordinates(changes.coordinates.currentValue);
     }
   }
 
   ngOnDestroy() {
     this.sub.unsubscribe();
-    if (this.sourceAdded) {
-      this.mapService.removeSource(this.id);
-      this.sourceAdded = false;
+    if (this.sourceAdded()) {
+      this.mapService.removeSource(this.id());
+      this.sourceAdded.set(false);
     }
   }
 
   private init() {
     const source: VideoSourceSpecification = {
       type: 'video',
-      urls: this.urls,
-      coordinates: this.coordinates,
+      urls: this.urls(),
+      coordinates: this.coordinates(),
     };
-    this.mapService.addSource(this.id, source);
-    this.sourceAdded = true;
+    this.mapService.addSource(this.id(), source);
+    this.sourceAdded.set(true);
   }
 }

--- a/projects/ngx-maplibre-gl/src/lib/source/video-source.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/video-source.component.ts
@@ -6,7 +6,7 @@ import {
   input,
 } from '@angular/core';
 import type { VideoSource, VideoSourceSpecification } from 'maplibre-gl';
-import { BaseSourceDirective } from './base-source.directive';
+import { SourceDirective } from './source.directive';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { tap } from 'rxjs';
 
@@ -23,7 +23,7 @@ import { tap } from 'rxjs';
   standalone: true,
 })
 export class VideoSourceComponent
-  extends BaseSourceDirective
+  extends SourceDirective
   implements OnChanges
 {
   /** Dynamic input */

--- a/projects/ngx-maplibre-gl/src/lib/source/video-source.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/video-source.component.ts
@@ -6,6 +6,7 @@ import {
   OnDestroy,
   OnInit,
   SimpleChanges,
+  inject,
 } from '@angular/core';
 import { VideoSource, VideoSourceSpecification } from 'maplibre-gl';
 import { fromEvent, Subscription } from 'rxjs';
@@ -13,9 +14,9 @@ import { filter } from 'rxjs/operators';
 import { MapService } from '../map/map.service';
 
 /**
- * `mgl-video-source` - a video source 
+ * `mgl-video-source` - a video source
  * @see [video](https://maplibre.org/maplibre-style-spec/sources/#video)
- * 
+ *
  * @category Source Components
  */
 @Component({
@@ -25,7 +26,11 @@ import { MapService } from '../map/map.service';
   standalone: true,
 })
 export class VideoSourceComponent
-  implements OnInit, OnDestroy, OnChanges, VideoSourceSpecification {
+  implements OnInit, OnDestroy, OnChanges, VideoSourceSpecification
+{
+  /** Init injection */
+  private readonly mapService = inject(MapService);
+
   /** Init input */
   @Input() id: string;
 
@@ -39,8 +44,6 @@ export class VideoSourceComponent
 
   private sourceAdded = false;
   private sub = new Subscription();
-
-  constructor(private mapService: MapService) {}
 
   ngOnInit() {
     const sub1 = this.mapService.mapLoaded$.subscribe(() => {

--- a/projects/ngx-maplibre-gl/src/lib/source/video-source.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/video-source.component.ts
@@ -26,15 +26,12 @@ import { MapService } from '../map/map.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
 })
-// VideoSourceSpecification
 export class VideoSourceComponent implements OnInit, OnDestroy, OnChanges {
   /** Init injection */
   private readonly mapService = inject(MapService);
 
   /** Init input */
   readonly id = input.required<string>();
-
-  /** Dynamic input */
   readonly urls = input.required<VideoSourceSpecification['urls']>();
   readonly coordinates =
     input.required<VideoSourceSpecification['coordinates']>();

--- a/projects/ngx-maplibre-gl/src/public_api.ts
+++ b/projects/ngx-maplibre-gl/src/public_api.ts
@@ -9,6 +9,7 @@ export * from './lib/control/control.component';
 export * from './lib/draggable/draggable.directive';
 export * from './lib/layer/layer.component';
 export * from './lib/image/image.component';
+export * from './lib/source/source.directive';
 export * from './lib/source/vector-source.component';
 export * from './lib/source/video-source.component';
 export * from './lib/source/canvas-source.component';

--- a/projects/showcase/src/app/app.component.ts
+++ b/projects/showcase/src/app/app.component.ts
@@ -13,8 +13,8 @@ import logo from '../assets/ngx-maplibre-gl.svg';
   imports: [RouterOutlet],
 })
 export class AppComponent {
-  private iconRegistry = inject(MatIconRegistry);
-  private sanitizer = inject(DomSanitizer);
+  private readonly iconRegistry = inject(MatIconRegistry);
+  private readonly sanitizer = inject(DomSanitizer);
 
   constructor() {
     this.iconRegistry.addSvgIconLiteral(

--- a/projects/showcase/src/app/demo/demo-index.component.ts
+++ b/projects/showcase/src/app/demo/demo-index.component.ts
@@ -3,7 +3,10 @@ import {
   ElementRef,
   NgZone,
   OnInit,
-  afterNextRender, viewChildren } from '@angular/core';
+  afterNextRender,
+  inject,
+  viewChildren,
+} from '@angular/core';
 import {
   MatSlideToggleChange,
   MatSlideToggleModule,
@@ -53,6 +56,10 @@ type RoutesByCategory = { [P in Category]: Routes };
   ],
 })
 export class DemoIndexComponent implements OnInit {
+  private readonly zone = inject(NgZone);
+  private readonly router = inject(Router);
+  private readonly activatedRoute = inject(ActivatedRoute);
+
   routes: RoutesByCategory;
   originalRoutes: RoutesByCategory;
   categories: Category[];
@@ -60,13 +67,11 @@ export class DemoIndexComponent implements OnInit {
   sidenavIsOpen = true;
   isEditMode = !!this.activatedRoute.snapshot.firstChild!.params.demoUrl;
 
-  exampleLinks = viewChildren<ElementRef>('exampleLink');
+  readonly exampleLinks = viewChildren<string, ElementRef>('exampleLink', {
+    read: ElementRef,
+  });
 
-  constructor(
-    private zone: NgZone,
-    private router: Router,
-    private activatedRoute: ActivatedRoute
-  ) {
+  constructor() {
     this.originalRoutes = <RoutesByCategory>(
       (<any>(
         groupBy(DEMO_ROUTES[0].children, (route) =>

--- a/projects/showcase/src/app/demo/demo-index.component.ts
+++ b/projects/showcase/src/app/demo/demo-index.component.ts
@@ -3,10 +3,7 @@ import {
   ElementRef,
   NgZone,
   OnInit,
-  QueryList,
-  ViewChildren,
-  afterNextRender,
-} from '@angular/core';
+  afterNextRender, viewChildren } from '@angular/core';
 import {
   MatSlideToggleChange,
   MatSlideToggleModule,
@@ -63,8 +60,7 @@ export class DemoIndexComponent implements OnInit {
   sidenavIsOpen = true;
   isEditMode = !!this.activatedRoute.snapshot.firstChild!.params.demoUrl;
 
-  @ViewChildren('exampleLink', { read: ElementRef })
-  exampleLinks: QueryList<ElementRef>;
+  exampleLinks = viewChildren<ElementRef>('exampleLink');
 
   constructor(
     private zone: NgZone,
@@ -136,7 +132,7 @@ export class DemoIndexComponent implements OnInit {
 
   private scrollInToActiveExampleLink() {
     this.zone.onStable.pipe(first()).subscribe(() => {
-      const activeLink = this.exampleLinks.find((elm) =>
+      const activeLink = this.exampleLinks().find((elm) =>
         (<HTMLElement>elm.nativeElement).classList.contains('active')
       );
       if (activeLink) {

--- a/projects/showcase/src/app/demo/examples/add-image-missing-generated.component.ts
+++ b/projects/showcase/src/app/demo/examples/add-image-missing-generated.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import {
   MapComponent,
   MapImageData,
@@ -16,8 +16,8 @@ import {
       (styleImageMissing)="generateImage($event)"
       [preserveDrawingBuffer]="true"
     >
-      @for (imageData of imagesData; track trackByImage($index, imageData)) {
-        <mgl-image [id]="imageData.id" [data]="imageData"></mgl-image>
+      @for (imageData of imagesData(); track imageData.id) {
+      <mgl-image [id]="imageData.id" [data]="imageData"></mgl-image>
       }
       <mgl-layer
         id="points"
@@ -69,10 +69,11 @@ import {
   `,
   styleUrls: ['./examples.css'],
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [MapComponent, ImageComponent, LayerComponent],
 })
 export class AddImageMissingGeneratedComponent {
-  imagesData: (MapImageData & { id: string })[] = [];
+  readonly imagesData = signal<(MapImageData & { id: string })[]>([]);
 
   generateImage({ id }: { id: string }) {
     // check if this missing icon is one this function can generate
@@ -103,10 +104,6 @@ export class AddImageMissingGeneratedComponent {
       height: width,
       data,
     };
-    this.imagesData = [...this.imagesData, imageData];
-  }
-
-  trackByImage(_idx: number, image: { id: string }) {
-    return image.id;
+    this.imagesData.update((imagesData) => [...imagesData, imageData]);
   }
 }

--- a/projects/showcase/src/app/demo/examples/cluster-html.component.ts
+++ b/projects/showcase/src/app/demo/examples/cluster-html.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, OnInit, input } from '@angular/core';
 import {
   CircleLayerSpecification,
   SymbolLayerSpecification,
@@ -24,7 +24,7 @@ import {
       [ngStyle]="{ font: font }"
     >
       @for (segment of segments; track segment) {
-        <path [attr.d]="segment.d" [ngStyle]="{ fill: segment.fill }" />
+      <path [attr.d]="segment.d" [ngStyle]="{ fill: segment.fill }" />
       }
       <circle [attr.cx]="r" [attr.cy]="r" [attr.r]="r0" fill="white" />
       <text dominant-baseline="central" [attr.transform]="textTransform">
@@ -36,7 +36,7 @@ import {
   imports: [NgStyle],
 })
 export class ClusterPointComponent implements OnInit {
-  @Input() properties: any;
+  properties = input<any>();
 
   w: number;
   r: number;
@@ -49,12 +49,13 @@ export class ClusterPointComponent implements OnInit {
 
   ngOnInit() {
     const offsets = [];
+    const properties = this.properties();
     const counts = [
-      this.properties.mag1,
-      this.properties.mag2,
-      this.properties.mag3,
-      this.properties.mag4,
-      this.properties.mag5,
+      properties.mag1,
+      properties.mag2,
+      properties.mag3,
+      properties.mag4,
+      properties.mag5,
     ];
     let total = 0;
     for (let i = 0; i < counts.length; i++) {
@@ -208,7 +209,7 @@ export class ClusterHtmlComponent {
     };
     this.circlePaint = {
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      'circle-color': [ 
+      'circle-color': [
         'case',
         mag1,
         COLORS[0],
@@ -221,7 +222,7 @@ export class ClusterHtmlComponent {
         COLORS[4],
       ],
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      'circle-opacity': 0.6, 
+      'circle-opacity': 0.6,
       // eslint-disable-next-line @typescript-eslint/naming-convention
       'circle-radius': 12,
     };

--- a/projects/showcase/src/app/demo/examples/cluster-html.component.ts
+++ b/projects/showcase/src/app/demo/examples/cluster-html.component.ts
@@ -1,8 +1,10 @@
 import { Component, OnInit, input } from '@angular/core';
-import {
+import type {
   CircleLayerSpecification,
   SymbolLayerSpecification,
   ExpressionSpecification,
+  GeoJSONSourceSpecification,
+  MapGeoJSONFeature
 } from 'maplibre-gl';
 import { NgStyle } from '@angular/common';
 import {
@@ -10,7 +12,7 @@ import {
   LayerComponent,
   MarkersForClustersComponent,
   GeoJSONSourceComponent,
-  ClusterPointDirective,
+  ClusterPointDirective
 } from '@maplibre/ngx-maplibre-gl';
 
 @Component({
@@ -36,7 +38,7 @@ import {
   imports: [NgStyle],
 })
 export class ClusterPointComponent implements OnInit {
-  properties = input<any>();
+  readonly properties = input<MapGeoJSONFeature['properties']>();
 
   w: number;
   r: number;
@@ -50,12 +52,13 @@ export class ClusterPointComponent implements OnInit {
   ngOnInit() {
     const offsets = [];
     const properties = this.properties();
+
     const counts = [
-      properties.mag1,
-      properties.mag2,
-      properties.mag3,
-      properties.mag4,
-      properties.mag5,
+      properties?.mag1,
+      properties?.mag2,
+      properties?.mag3,
+      properties?.mag4,
+      properties?.mag5,
     ];
     let total = 0;
     for (let i = 0; i < counts.length; i++) {
@@ -174,7 +177,7 @@ const COLORS = ['#fed976', '#feb24c', '#fd8d3c', '#fc4e2a', '#e31a1c'];
   ],
 })
 export class ClusterHtmlComponent {
-  clusterProperties: any;
+  clusterProperties: GeoJSONSourceSpecification['clusterProperties'];
   circlePaint: CircleLayerSpecification['paint'];
   labelLayout: SymbolLayerSpecification['layout'];
   labelPaint: SymbolLayerSpecification['paint'];

--- a/projects/showcase/src/app/demo/examples/live-update-image-srource.component.ts
+++ b/projects/showcase/src/app/demo/examples/live-update-image-srource.component.ts
@@ -59,7 +59,7 @@ export class LiveUpdateImageSourceComponent implements OnDestroy {
     this.coordinates = this.makeRectangle(this.center);
     afterNextRender(() => {
       const points = data.features[0].geometry!.coordinates;
-      const coordinates = points.map((c: any) => this.makeRectangle(c));
+      const coordinates = points.map((c: number[]) => this.makeRectangle(c));
 
       this.center = points[0];
       this.coordinates = coordinates[0];

--- a/projects/showcase/src/app/demo/examples/live-update-image-srource.component.ts
+++ b/projects/showcase/src/app/demo/examples/live-update-image-srource.component.ts
@@ -1,4 +1,10 @@
-import { Component, NgZone, OnDestroy, afterNextRender } from '@angular/core';
+import {
+  Component,
+  NgZone,
+  OnDestroy,
+  afterNextRender,
+  inject,
+} from '@angular/core';
 import {
   MapComponent,
   ImageSourceComponent,
@@ -39,6 +45,8 @@ import data from './hike.geo.json';
   imports: [MapComponent, ImageSourceComponent, LayerComponent],
 })
 export class LiveUpdateImageSourceComponent implements OnDestroy {
+  private readonly ngZone = inject(NgZone);
+
   private timer: ReturnType<typeof setInterval>;
   private readonly size = 0.001;
 
@@ -46,12 +54,12 @@ export class LiveUpdateImageSourceComponent implements OnDestroy {
   url = 'assets/red.png';
   coordinates: number[][];
 
-  constructor(private ngZone: NgZone) {
+  constructor() {
     this.center = data.features[0].geometry!.coordinates[0];
     this.coordinates = this.makeRectangle(this.center);
     afterNextRender(() => {
       const points = data.features[0].geometry!.coordinates;
-      const coordinates = points.map((c) => this.makeRectangle(c));
+      const coordinates = points.map((c: any) => this.makeRectangle(c));
 
       this.center = points[0];
       this.coordinates = coordinates[0];

--- a/projects/showcase/src/app/demo/examples/ngx-cluster-html.component.ts
+++ b/projects/showcase/src/app/demo/examples/ngx-cluster-html.component.ts
@@ -1,11 +1,13 @@
 import {
   Component,
-  Input,
   OnChanges,
   SimpleChanges,
   afterNextRender,
-  OnDestroy,
   viewChild,
+  input,
+  signal,
+  inject,
+  DestroyRef,
 } from '@angular/core';
 import {
   MatPaginator,
@@ -26,14 +28,14 @@ import { MatListModule } from '@angular/material/list';
   selector: 'showcase-cluster-popup',
   template: `
     <mat-list>
-    @for (leaf of leaves; track leaf) {
-        <mat-list-item>
-          {{ leaf.properties?.['Primary ID'] }}
-        </mat-list-item>
+      @for (leaf of leaves(); track leaf) {
+      <mat-list-item>
+        {{ leaf.properties?.['Primary ID'] }}
+      </mat-list-item>
       }
     </mat-list>
     <mat-paginator
-      [length]="selectedCluster.properties?.point_count"
+      [length]="selectedCluster().properties?.point_count"
       [pageSize]="5"
       (page)="changePage($event)"
     ></mat-paginator>
@@ -42,12 +44,16 @@ import { MatListModule } from '@angular/material/list';
   imports: [MatListModule, MatPaginatorModule],
 })
 export class ClusterPopupComponent implements OnChanges {
-  @Input() selectedCluster: { geometry: GeoJSON.Point; properties: any };
-  @Input() clusterComponent: GeoJSONSourceComponent;
+  readonly selectedCluster = input.required<{
+    geometry: GeoJSON.Point;
+    properties: any;
+  }>();
+
+  readonly clusterComponent = input.required<GeoJSONSourceComponent>();
 
   readonly paginator = viewChild.required(MatPaginator);
 
-  leaves: GeoJSON.Feature<GeoJSON.Geometry>[];
+  readonly leaves = signal<GeoJSON.Feature<GeoJSON.Geometry>[]>([]);
 
   ngOnChanges(changes: SimpleChanges) {
     this.changePage();
@@ -61,11 +67,14 @@ export class ClusterPopupComponent implements OnChanges {
     if (pageEvent) {
       offset = pageEvent.pageIndex * 5;
     }
-    this.leaves = await this.clusterComponent.getClusterLeaves(
-      this.selectedCluster.properties!.cluster_id,
+
+    const leaves = await this.clusterComponent().getClusterLeaves(
+      this.selectedCluster().properties.cluster_id,
       5,
       offset
     );
+
+    this.leaves.set(leaves);
   }
 }
 
@@ -87,39 +96,35 @@ export class ClusterPopupComponent implements OnChanges {
       [center]="[-103.59179687498357, 40.66995747013945]"
       [preserveDrawingBuffer]="true"
     >
-      @if (earthquakes) {
-        <mgl-geojson-source
-          #clusterComponent
-          id="earthquakes"
-          [data]="earthquakes"
-          [cluster]="true"
-          [clusterRadius]="50"
-          [clusterMaxZoom]="14"
-        ></mgl-geojson-source>
-        <mgl-markers-for-clusters source="earthquakes">
-          <ng-template mglPoint let-feature>
-            <div class="marker" [title]="feature.properties['Secondary ID']">
-              {{ feature.properties['Primary ID'] }}
-            </div>
-          </ng-template>
-          <ng-template mglClusterPoint let-feature>
-            <div
-              class="marker-cluster"
-              (click)="selectCluster($event, feature)"
-            >
-              {{ feature.properties?.point_count }}
-            </div>
-          </ng-template>
-        </mgl-markers-for-clusters>
-        @if (selectedCluster) {
-          <mgl-popup [feature]="selectedCluster">
-            <showcase-cluster-popup
-              [clusterComponent]="clusterComponent"
-              [selectedCluster]="selectedCluster"
-            ></showcase-cluster-popup>
-          </mgl-popup>
-        }
-      }
+      @if (earthquakes(); as earthquakesValue) {
+      <mgl-geojson-source
+        #clusterComponent
+        id="earthquakes"
+        [data]="earthquakesValue"
+        [cluster]="true"
+        [clusterRadius]="50"
+        [clusterMaxZoom]="14"
+      ></mgl-geojson-source>
+      <mgl-markers-for-clusters source="earthquakes">
+        <ng-template mglPoint let-feature>
+          <div class="marker" [title]="feature.properties['Secondary ID']">
+            {{ feature.properties["Primary ID"] }}
+          </div>
+        </ng-template>
+        <ng-template mglClusterPoint let-feature>
+          <div class="marker-cluster" (click)="selectCluster($event, feature)">
+            {{ feature.properties?.point_count }}
+          </div>
+        </ng-template>
+      </mgl-markers-for-clusters>
+      @if (selectedCluster(); as selectedClusterValue) {
+      <mgl-popup [feature]="selectedClusterValue">
+        <showcase-cluster-popup
+          [clusterComponent]="clusterComponent"
+          [selectedCluster]="selectedClusterValue"
+        ></showcase-cluster-popup>
+      </mgl-popup>
+      } }
     </mgl-map>
   `,
   styleUrls: ['./examples.css', './ngx-cluster-html.component.css'],
@@ -134,35 +139,37 @@ export class ClusterPopupComponent implements OnChanges {
     ClusterPopupComponent,
   ],
 })
-export class NgxClusterHtmlComponent implements OnDestroy {
-  earthquakes: GeoJSON.FeatureCollection;
-  selectedCluster: { geometry: GeoJSON.Point; properties: any };
-  timer: ReturnType<typeof setInterval>;
+export class NgxClusterHtmlComponent {
+  private destroyRef = inject(DestroyRef);
+  readonly earthquakes = signal<GeoJSON.FeatureCollection | null>(null);
+
+  readonly selectedCluster = signal<{
+    geometry: GeoJSON.Point;
+    properties: any;
+  } | null>(null);
 
   constructor() {
+    let timer: ReturnType<typeof setInterval>;
     afterNextRender(async () => {
       const earthquakes: GeoJSON.FeatureCollection = (await import(
         './earthquakes.geo.json'
       )) as any;
-      this.timer = setInterval(() => {
+      timer = setInterval(() => {
         if (earthquakes.features.length) {
           earthquakes.features.pop();
         }
-        this.earthquakes = { ...earthquakes };
+        this.earthquakes.set({ ...earthquakes });
       }, 500);
     });
-  }
-
-  ngOnDestroy() {
-    clearInterval(this.timer);
+    this.destroyRef.onDestroy(() => clearInterval(timer));
   }
 
   selectCluster(event: MouseEvent, feature: any) {
     event.stopPropagation(); // This is needed, otherwise the popup will close immediately
     // Change the ref, to trigger mgl-popup onChanges (when the user click on the same cluster)
-    this.selectedCluster = {
+    this.selectedCluster.set({
       geometry: feature.geometry,
       properties: feature.properties,
-    };
+    });
   }
 }

--- a/projects/showcase/src/app/demo/examples/ngx-cluster-html.component.ts
+++ b/projects/showcase/src/app/demo/examples/ngx-cluster-html.component.ts
@@ -2,10 +2,10 @@ import {
   Component,
   Input,
   OnChanges,
-  ViewChild,
   SimpleChanges,
   afterNextRender,
   OnDestroy,
+  viewChild,
 } from '@angular/core';
 import {
   MatPaginator,
@@ -26,7 +26,7 @@ import { MatListModule } from '@angular/material/list';
   selector: 'showcase-cluster-popup',
   template: `
     <mat-list>
-      @for (leaf of leaves; track leaf) {
+    @for (leaf of leaves; track leaf) {
         <mat-list-item>
           {{ leaf.properties?.['Primary ID'] }}
         </mat-list-item>
@@ -45,14 +45,14 @@ export class ClusterPopupComponent implements OnChanges {
   @Input() selectedCluster: { geometry: GeoJSON.Point; properties: any };
   @Input() clusterComponent: GeoJSONSourceComponent;
 
-  @ViewChild(MatPaginator, { static: true }) paginator: MatPaginator;
+  readonly paginator = viewChild.required(MatPaginator);
 
   leaves: GeoJSON.Feature<GeoJSON.Geometry>[];
 
   ngOnChanges(changes: SimpleChanges) {
     this.changePage();
     if (changes.selectedCluster && !changes.selectedCluster.isFirstChange()) {
-      this.paginator.firstPage();
+      this.paginator().firstPage();
     }
   }
 
@@ -64,7 +64,7 @@ export class ClusterPopupComponent implements OnChanges {
     this.leaves = await this.clusterComponent.getClusterLeaves(
       this.selectedCluster.properties!.cluster_id,
       5,
-      offset,
+      offset
     );
   }
 }

--- a/projects/showcase/src/app/demo/examples/toggle-layers.component.ts
+++ b/projects/showcase/src/app/demo/examples/toggle-layers.component.ts
@@ -1,11 +1,11 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import {
   LayerComponent,
   MapComponent,
   VectorSourceComponent,
 } from '@maplibre/ngx-maplibre-gl';
-import { LayerSpecification } from 'maplibre-gl';
+import type { LayerSpecification } from 'maplibre-gl';
 
 @Component({
   selector: 'showcase-demo',
@@ -32,7 +32,7 @@ import { LayerSpecification } from 'maplibre-gl';
         id="countries-layer"
         type="line"
         source="countries"
-        [layout]="layouts['countries']"
+        [layout]="layouts()['countries']"
         [paint]="{
           'line-color': 'blue'
         }"
@@ -43,7 +43,7 @@ import { LayerSpecification } from 'maplibre-gl';
         id="names"
         type="symbol"
         source="everything"
-        [layout]="layouts['names']"
+        [layout]="layouts()['names']"
         sourceLayer="place"
       >
       </mgl-layer>
@@ -69,6 +69,7 @@ import { LayerSpecification } from 'maplibre-gl';
   `,
   styleUrls: ['./examples.css', './toggle-layers.component.css'],
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     MapComponent,
     VectorSourceComponent,
@@ -77,7 +78,7 @@ import { LayerSpecification } from 'maplibre-gl';
   ],
 })
 export class ToggleLayersComponent {
-  layouts: { [key: string]: LayerSpecification['layout'] } = {
+  readonly layouts = signal<{ [key: string]: LayerSpecification['layout'] }>({
     countries: {
       visibility: 'none',
     },
@@ -88,15 +89,18 @@ export class ToggleLayersComponent {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       'text-size': 30,
     },
-  };
+  });
 
   toggleLayer(evt: { value: string }) {
-    this.layouts[evt.value] = {
-      ...this.layouts[evt.value],
-      visibility:
-        (this.layouts[evt.value] as any).visibility === 'visible'
-          ? 'none'
-          : 'visible',
-    };
+    this.layouts.update((layouts) => ({
+      ...layouts,
+      [evt.value]: {
+        ...layouts[evt.value],
+        visibility:
+          (layouts[evt.value] as any).visibility === 'visible'
+            ? 'none'
+            : 'visible',
+      },
+    }));
   }
 }

--- a/projects/showcase/src/app/demo/stackblitz-edit/demo-file-loader.service.ts
+++ b/projects/showcase/src/app/demo/stackblitz-edit/demo-file-loader.service.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { forkJoin, Observable, of } from 'rxjs';
 import { map, shareReplay, switchMap } from 'rxjs/operators';
 
@@ -7,9 +7,10 @@ const FILES_PATH = 'app/demo/examples/';
 
 @Injectable({ providedIn: 'root' })
 export class DemoFileLoaderService {
+  private readonly http = inject(HttpClient);
   private fileCache = new Map<string, Observable<Record<string, string>>>();
 
-  constructor(private http: HttpClient) {
+  constructor() {
     // Preload this file since it's used in every demos
     this.loadFile('example.css');
   }

--- a/projects/showcase/src/app/demo/stackblitz-edit/stackblitz-edit-guard.service.ts
+++ b/projects/showcase/src/app/demo/stackblitz-edit/stackblitz-edit-guard.service.ts
@@ -1,10 +1,10 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivate, Router } from '@angular/router';
 import { DEMO_ROUTES } from '../routes';
 
 @Injectable({ providedIn: 'root' })
 export class StackblitzEditGuard implements CanActivate {
-  constructor(private router: Router) {}
+  private readonly router = inject(Router);
 
   canActivate(route: ActivatedRouteSnapshot) {
     if (DEMO_ROUTES[0].children!.some((r) => r.path === route.params.demoUrl)) {

--- a/projects/showcase/src/app/demo/stackblitz-edit/stackblitz-edit.component.ts
+++ b/projects/showcase/src/app/demo/stackblitz-edit/stackblitz-edit.component.ts
@@ -50,7 +50,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
   imports: [MatProgressSpinnerModule],
 })
 export class StackblitzEditComponent implements AfterViewInit, OnDestroy {
-  stackblitzContainer = viewChild.required<ElementRef>('container');
+  stackblitzContainer = viewChild.required<ElementRef<HTMLDivElement>>('container');
 
   loading = true;
 

--- a/projects/showcase/src/app/demo/stackblitz-edit/stackblitz-edit.component.ts
+++ b/projects/showcase/src/app/demo/stackblitz-edit/stackblitz-edit.component.ts
@@ -6,9 +6,7 @@ import {
   Component,
   ElementRef,
   NgZone,
-  OnDestroy,
-  ViewChild,
-} from '@angular/core';
+  OnDestroy, viewChild } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import StackBlitzSDK, { VM } from '@stackblitz/sdk';
 import { Subscription, forkJoin, from, of } from 'rxjs';
@@ -52,7 +50,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
   imports: [MatProgressSpinnerModule],
 })
 export class StackblitzEditComponent implements AfterViewInit, OnDestroy {
-  @ViewChild('container') stackblitzContainer: ElementRef;
+  stackblitzContainer = viewChild.required<ElementRef>('container');
 
   loading = true;
 
@@ -126,7 +124,7 @@ export class StackblitzEditComponent implements AfterViewInit, OnDestroy {
     );
     await this.zone.runOutsideAngular(async () => {
       this.vm = await StackBlitzSDK.embedProject(
-        this.stackblitzContainer.nativeElement,
+        this.stackblitzContainer().nativeElement,
         project,
         {
           hideExplorer: true,

--- a/projects/showcase/src/app/home/home-index.component.ts
+++ b/projects/showcase/src/app/home/home-index.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import { AnimationOptions } from 'maplibre-gl';
 import { MatIconModule } from '@angular/material/icon';
 import { MapComponent } from '@maplibre/ngx-maplibre-gl';
@@ -8,7 +8,7 @@ import { MapComponent } from '@maplibre/ngx-maplibre-gl';
     <mgl-map
       [style]="'https://demotiles.maplibre.org/style.json'"
       [zoom]="[2]"
-      [center]="center"
+      [center]="center()"
       [centerWithPanTo]="true"
       [panToOptions]="panToOptions"
       [interactive]="false"
@@ -18,25 +18,29 @@ import { MapComponent } from '@maplibre/ngx-maplibre-gl';
   `,
   styleUrls: ['./home-index.component.scss'],
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [MapComponent, MatIconModule],
 })
 export class HomeIndexComponent {
-  center = [0, 0];
-  panToOptions: AnimationOptions = { duration: 10000, easing: (t) => t };
+  readonly center = signal<[number, number]>([0, 0]);
+  readonly panToOptions: AnimationOptions = {
+    duration: 10000,
+    easing: (t) => t,
+  };
 
   moveCenter() {
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
       return;
     }
-    const targetY = this.center[0];
+    const targetY = this.center()[0];
     if (targetY === 0) {
-      this.center = [90, 0];
+      this.center.set([90, 0]);
     } else if (targetY === 90) {
-      this.center = [180, 0];
+      this.center.set([180, 0]);
     } else if (targetY === 180) {
-      this.center = [-90, 0];
+      this.center.set([-90, 0]);
     } else if (targetY === -90) {
-      this.center = [0, 0];
+      this.center.set([0, 0]);
     }
   }
 }

--- a/projects/showcase/src/app/shared/layout/layout-toolbar-menu.component.ts
+++ b/projects/showcase/src/app/shared/layout/layout-toolbar-menu.component.ts
@@ -3,11 +3,12 @@ import {
   ApplicationRef,
   Component,
   ComponentFactoryResolver,
+  DestroyRef,
   Injector,
   Input,
-  OnDestroy,
-  ViewChild,
-  afterNextRender
+  afterNextRender,
+  inject,
+  viewChild,
 } from '@angular/core';
 
 @Component({
@@ -20,17 +21,18 @@ import {
   standalone: true,
   imports: [PortalModule],
 })
-export class LayoutToolbarMenuComponent implements OnDestroy {
+export class LayoutToolbarMenuComponent {
+  private readonly componentFactoryResolver = inject(ComponentFactoryResolver);
+  private readonly injector = inject(Injector);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly appRef = inject(ApplicationRef);
+
   @Input() position: 'left' | 'right';
 
   private portalOutlet: DomPortalOutlet;
-  @ViewChild(CdkPortal) portal: CdkPortal;
+  readonly portal = viewChild.required(CdkPortal);
 
-  constructor(
-    private componentFactoryResolver: ComponentFactoryResolver,
-    private injector: Injector,
-    private appRef: ApplicationRef
-  ) {
+  constructor() {
     afterNextRender(() => {
       this.portalOutlet = new DomPortalOutlet(
         document.querySelector(
@@ -42,11 +44,9 @@ export class LayoutToolbarMenuComponent implements OnDestroy {
         this.appRef,
         this.injector
       );
-      this.portalOutlet.attach(this.portal);
+      this.portalOutlet.attach(this.portal());
     });
-  }
 
-  ngOnDestroy() {
-    this.portalOutlet?.detach();
+    this.destroyRef.onDestroy(() => this.portalOutlet?.detach());
   }
 }

--- a/projects/showcase/src/app/shared/layout/layout-toolbar-menu.component.ts
+++ b/projects/showcase/src/app/shared/layout/layout-toolbar-menu.component.ts
@@ -5,9 +5,9 @@ import {
   ComponentFactoryResolver,
   DestroyRef,
   Injector,
-  Input,
   afterNextRender,
   inject,
+  input,
   viewChild,
 } from '@angular/core';
 
@@ -27,7 +27,7 @@ export class LayoutToolbarMenuComponent {
   private readonly destroyRef = inject(DestroyRef);
   private readonly appRef = inject(ApplicationRef);
 
-  @Input() position: 'left' | 'right';
+  readonly position = input<'left' | 'right'>();
 
   private portalOutlet: DomPortalOutlet;
   readonly portal = viewChild.required(CdkPortal);
@@ -36,7 +36,7 @@ export class LayoutToolbarMenuComponent {
     afterNextRender(() => {
       this.portalOutlet = new DomPortalOutlet(
         document.querySelector(
-          this.position === 'left'
+          this.position() === 'left'
             ? '#layout-left-custom-items'
             : '#layout-right-custom-items'
         )!,


### PR DESCRIPTION
Migration of the following decorators:

- @Output => output()
- @ViewChild() => viewChild()
-  @ViewChildren() => viewChildren()
-  @ContentChildren() => contentChildren()
-  @ContentChild() => contentChild()

Migrate to new methode for dependency injection :

constructor(myService:MyService){} =>  myService = inject(MyService);