### PR TITLE
fix: remove source based on current id during source update

### DIFF
--- a/projects/ngx-maplibre-gl/src/lib/source/source.directive.spec.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/source.directive.spec.ts
@@ -1,0 +1,104 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ComponentRef,
+  DestroyRef,
+  inject,
+  input,
+  OnChanges,
+  SimpleChanges,
+} from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { of, tap } from 'rxjs';
+import { MapService } from '../map/map.service';
+import { SourceDirective } from './source.directive';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+
+const getMapServiceStub = () =>
+  jasmine.createSpyObj(['removeSource', 'addSource', 'getSource'], {
+    mapLoaded$: of(true),
+    mapInstance: new EventTarget(),
+  });
+const destroyRefStub = () => jasmine.createSpyObj(['onDestroy']);
+
+@Component({
+  template: '',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  hostDirectives: [{ directive: SourceDirective, inputs: ['id'] }],
+  standalone: true,
+})
+export class TestSourceComponent implements OnChanges {
+  public readonly sourceDirective = inject(SourceDirective);
+  readonly testInput = input<string>();
+
+  constructor() {
+    this.sourceDirective.loadSource$
+      .pipe(
+        tap(() => this.sourceDirective.addSource({ type: 'vector' })),
+        takeUntilDestroyed()
+      )
+      .subscribe();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (!this.sourceDirective.sourceId()) {
+      return;
+    }
+    if (changes.testInput && !changes.testInput.isFirstChange()) {
+      this.sourceDirective.refresh();
+    }
+  }
+}
+
+describe('SourceDirective', () => {
+  let mapServiceStub: jasmine.SpyObj<MapService>;
+  let fixture: ComponentFixture<TestSourceComponent>;
+  let componentRef: ComponentRef<TestSourceComponent>;
+  let directive: SourceDirective;
+
+  beforeEach(waitForAsync(() => {
+    mapServiceStub = getMapServiceStub();
+
+    TestBed.configureTestingModule({
+      imports: [TestSourceComponent, SourceDirective],
+      providers: [
+        { provide: MapService, useValue: mapServiceStub },
+        { provide: DestroyRef, useValue: destroyRefStub },
+        SourceDirective,
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestSourceComponent);
+    componentRef = fixture.componentRef;
+    directive = componentRef.instance.sourceDirective;
+  }));
+
+  it('should remove and recreate source on update', () => {
+    componentRef.setInput('id', 'test-id-1');
+    componentRef.setInput('testInput', 'test value');
+
+    directive.loadSource$.subscribe();
+
+    fixture.detectChanges();
+
+    componentRef.setInput('id', 'test-id-2');
+    componentRef.setInput('testInput', 'new value');
+
+    fixture.detectChanges();
+
+    expect(mapServiceStub.removeSource).toHaveBeenCalledOnceWith('test-id-1');
+    expect(mapServiceStub.addSource).toHaveBeenCalledTimes(2);
+    expect(mapServiceStub.addSource.calls.argsFor(0)).toEqual([
+      'test-id-1',
+      {
+        type: 'vector',
+      },
+    ]);
+    expect(mapServiceStub.addSource.calls.argsFor(1)).toEqual([
+      'test-id-2',
+      {
+        type: 'vector',
+      },
+    ]);
+  });
+});

--- a/projects/ngx-maplibre-gl/src/lib/source/source.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/source.directive.ts
@@ -21,13 +21,17 @@ import { Source, SourceSpecification } from 'maplibre-gl';
 })
 export class SourceDirective implements OnInit {
   /** Init injection */
-  readonly mapService = inject(MapService);
+  private readonly mapService = inject(MapService);
   private readonly destroyRef = inject(DestroyRef);
 
   /**  Init input */
-  readonly id = input.required<string>();
-  readonly sourceId = signal<string | null>(null);
+  public readonly id = input.required<string>();
 
+  /** 
+   * @internal
+   * Used to store the current source id and make sure removeSource is only called once.
+   */
+  private readonly sourceId = signal<string | null>(null);
   private readonly loadSourceSubject = new Subject<void>();
   readonly loadSource$ = this.loadSourceSubject.asObservable();
 

--- a/projects/ngx-maplibre-gl/src/lib/source/source.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/source.directive.ts
@@ -56,8 +56,9 @@ export class SourceDirective implements OnInit {
   }
 
   removeSource() {
-    if (this.sourceId()) {
-      this.mapService.removeSource(this.id());
+    const currentId = this.sourceId();
+    if (currentId) {
+      this.mapService.removeSource(currentId);
       this.sourceId.set(null);
     }
   }

--- a/projects/ngx-maplibre-gl/src/lib/source/source.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/source/source.directive.ts
@@ -21,7 +21,7 @@ import { Source, SourceSpecification } from 'maplibre-gl';
 })
 export class SourceDirective implements OnInit {
   /** Init injection */
-  private readonly mapService = inject(MapService);
+  readonly mapService = inject(MapService);
   private readonly destroyRef = inject(DestroyRef);
 
   /**  Init input */
@@ -31,7 +31,7 @@ export class SourceDirective implements OnInit {
    * @internal
    * Used to store the current source id and make sure removeSource is only called once.
    */
-  private readonly sourceId = signal<string | null>(null);
+  readonly sourceId = signal<string | null>(null);
   private readonly loadSourceSubject = new Subject<void>();
   readonly loadSource$ = this.loadSourceSubject.asObservable();
 


### PR DESCRIPTION
Fixes #205

Current refresh mechanism of the source directive fails when updating the source id.
This is because it bases the removal call on the new id `this.id()` instead of the current one `this.sourceId()`.