### PR TITLE
Update maplibre-gl to 5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@stackblitz/sdk": "^1.11.0",
         "express": "^4.21.2",
         "lodash-es": "^4.17.21",
-        "maplibre-gl": "^4.6.0",
+        "maplibre-gl": "^5.0.0",
         "rxjs": "7.8.1",
         "scroll-into-view-if-needed": "^3.1.0",
         "tslib": "^2.6.3",
@@ -5870,17 +5870,16 @@
       }
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "20.3.1",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-20.3.1.tgz",
-      "integrity": "sha512-5ueL4UDitzVtceQ8J4kY+Px3WK+eZTsmGwha3MBKHKqiHvKrjWWwBCIl1K8BuJSc5OFh83uI8IFNoFvQxX2uUw==",
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-22.0.1.tgz",
+      "integrity": "sha512-V7bSw7Ui6+NhpeeuYqGoqamvKuy+3+uCvQ/t4ZJkwN8cx527CAlQQQ2kp+w5R9q+Tw6bUAH+fsq+mPEkicgT8g==",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/unitbezier": "^0.0.1",
         "json-stringify-pretty-compact": "^4.0.0",
         "minimist": "^1.2.8",
-        "quickselect": "^2.0.0",
+        "quickselect": "^3.0.0",
         "rw": "^1.3.3",
-        "sort-object": "^3.0.3",
         "tinyqueue": "^3.0.0"
       },
       "bin": {
@@ -5896,11 +5895,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/quickselect": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
-      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
       "version": "3.0.3",
@@ -7105,9 +7099,9 @@
       }
     },
     "node_modules/@types/geojson": {
-      "version": "7946.0.14",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
-      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
+      "version": "7946.0.15",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.15.tgz",
+      "integrity": "sha512-9oSxFzDCT2Rj6DfcHF8G++jxBKS7mBqXl5xrRW+Kbvjry6Uduya2iiwqHPhVXpasAVMBYKkEPGgKhd3+/HZ6xA=="
     },
     "node_modules/@types/geojson-vt": {
       "version": "3.2.5",
@@ -8146,14 +8140,6 @@
         "dequal": "^2.0.3"
       }
     },
-    "node_modules/arr-union": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -8208,14 +8194,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/assign-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/astral-regex": {
@@ -8696,23 +8674,6 @@
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/bytewise": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
-      "integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
-      "dependencies": {
-        "bytewise-core": "^1.2.2",
-        "typewise": "^1.0.3"
-      }
-    },
-    "node_modules/bytewise-core": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
-      "integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
-      "dependencies": {
-        "typewise-core": "^1.2"
       }
     },
     "node_modules/cacache": {
@@ -10916,9 +10877,9 @@
       }
     },
     "node_modules/earcut": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.0.tgz",
-      "integrity": "sha512-41Fs7Q/PLq1SDbqjsgcY7GA42T0jvaCNGXgGtsNdvg+Yv8eIu06bxv4/PoREkZ9nMDNwnUSG9OFB9+yv8eKhDg=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.1.tgz",
+      "integrity": "sha512-0l1/0gOjESMeQyYaK5IDiPNvFeu93Z/cO0TjZh9eZ1vyCtZnA7KMZ8rQggpsJHIbGSdrqYq9OhuveadOVHCshw=="
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -11795,17 +11756,6 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
     },
-    "node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -12540,14 +12490,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-value": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/getos": {
@@ -13638,14 +13580,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -13786,6 +13720,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
       "dependencies": {
         "isobject": "^3.0.1"
       },
@@ -13899,6 +13834,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16268,9 +16204,9 @@
       }
     },
     "node_modules/maplibre-gl": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.6.0.tgz",
-      "integrity": "sha512-zobZK+fE+XM+7K81fk5pSBYWZlTGjGT0P96y2fR4DV2ry35ZBfAd0uWNatll69EgYeE+uOhN1MvEk+z1PCuyOQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.0.0.tgz",
+      "integrity": "sha512-WG8IYFK2gfJYXvWjlqg1yavo/YO/JlNkblAJMt19sjIafP5oJzTgXFiOLUIYkjtrv5pKiAWuSYsx4CD3ithJqw==",
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
@@ -16279,14 +16215,14 @@
         "@mapbox/unitbezier": "^0.0.1",
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^20.3.1",
-        "@types/geojson": "^7946.0.14",
+        "@maplibre/maplibre-gl-style-spec": "^22.0.1",
+        "@types/geojson": "^7946.0.15",
         "@types/geojson-vt": "3.2.5",
         "@types/mapbox__point-geometry": "^0.1.4",
         "@types/mapbox__vector-tile": "^1.3.4",
         "@types/pbf": "^3.0.5",
         "@types/supercluster": "^7.1.3",
-        "earcut": "^3.0.0",
+        "earcut": "^3.0.1",
         "geojson-vt": "^4.0.2",
         "gl-matrix": "^3.4.3",
         "global-prefix": "^4.0.0",
@@ -20061,20 +19997,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/set-value": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
-      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
-      "dependencies": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -20318,38 +20240,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/sort-asc": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.2.0.tgz",
-      "integrity": "sha512-umMGhjPeHAI6YjABoSTrFp2zaBtXBej1a0yKkuMUyjjqu6FJsTF+JYwCswWDg+zJfk/5npWUUbd33HH/WLzpaA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sort-desc": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.2.0.tgz",
-      "integrity": "sha512-NqZqyvL4VPW+RAxxXnB8gvE1kyikh8+pR+T+CXLksVRN9eiQqkQlPwqWYU0mF9Jm7UnctShlxLyAt1CaBOTL1w==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sort-object": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-3.0.3.tgz",
-      "integrity": "sha512-nK7WOY8jik6zaG9CRwZTaD5O7ETWDLZYMM12pqY8htll+7dYeqGfEUPcUBHOpSJg2vJOrvFIY2Dl5cX2ih1hAQ==",
-      "dependencies": {
-        "bytewise": "^1.1.0",
-        "get-value": "^2.0.2",
-        "is-extendable": "^0.1.1",
-        "sort-asc": "^0.2.0",
-        "sort-desc": "^0.2.0",
-        "union-value": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
@@ -20490,40 +20380,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/split-string": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-      "dependencies": {
-        "extend-shallow": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/split-string/node_modules/extend-shallow": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
-      "dependencies": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/split-string/node_modules/is-extendable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-      "dependencies": {
-        "is-plain-object": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/split2": {
@@ -21573,19 +21429,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/typewise": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
-      "integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
-      "dependencies": {
-        "typewise-core": "^1.2.0"
-      }
-    },
-    "node_modules/typewise-core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
-      "integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg=="
-    },
     "node_modules/uc.micro": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
@@ -21661,20 +21504,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/union-value": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
-      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
-      "dependencies": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/unique-filename": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@stackblitz/sdk": "^1.11.0",
     "express": "^4.21.2",
     "lodash-es": "^4.17.21",
-    "maplibre-gl": "^4.6.0",
+    "maplibre-gl": "^5.0.0",
     "rxjs": "7.8.1",
     "scroll-into-view-if-needed": "^3.1.0",
     "tslib": "^2.6.3",

--- a/projects/ngx-maplibre-gl/package-lock.json
+++ b/projects/ngx-maplibre-gl/package-lock.json
@@ -11,7 +11,7 @@
       "peerDependencies": {
         "@angular/common": ">= 18.0.0",
         "@angular/core": ">= 18.0.0",
-        "maplibre-gl": ">= 4.1.0",
+        "maplibre-gl": ">= 5.0.0",
         "rxjs": ">= 7.8.1"
       }
     },
@@ -106,19 +106,18 @@
       }
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "20.3.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-20.3.0.tgz",
-      "integrity": "sha512-eSiQ3E5LUSxAOY9ABXGyfNhout2iEa6mUxKeaQ9nJ8NL1NuaQYU7zKqzx/LEYcXe1neT4uYAgM1wYZj3fTSXtA==",
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-22.0.1.tgz",
+      "integrity": "sha512-V7bSw7Ui6+NhpeeuYqGoqamvKuy+3+uCvQ/t4ZJkwN8cx527CAlQQQ2kp+w5R9q+Tw6bUAH+fsq+mPEkicgT8g==",
       "peer": true,
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/unitbezier": "^0.0.1",
         "json-stringify-pretty-compact": "^4.0.0",
         "minimist": "^1.2.8",
-        "quickselect": "^2.0.0",
+        "quickselect": "^3.0.0",
         "rw": "^1.3.3",
-        "sort-object": "^3.0.3",
-        "tinyqueue": "^2.0.3"
+        "tinyqueue": "^3.0.0"
       },
       "bin": {
         "gl-style-format": "dist/gl-style-format.mjs",
@@ -126,22 +125,10 @@
         "gl-style-validate": "dist/gl-style-validate.mjs"
       }
     },
-    "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/quickselect": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
-      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
-      "peer": true
-    },
-    "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/tinyqueue": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
-      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
-      "peer": true
-    },
     "node_modules/@types/geojson": {
-      "version": "7946.0.14",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
-      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==",
+      "version": "7946.0.15",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.15.tgz",
+      "integrity": "sha512-9oSxFzDCT2Rj6DfcHF8G++jxBKS7mBqXl5xrRW+Kbvjry6Uduya2iiwqHPhVXpasAVMBYKkEPGgKhd3+/HZ6xA==",
       "peer": true
     },
     "node_modules/@types/geojson-vt": {
@@ -185,60 +172,11 @@
         "@types/geojson": "*"
       }
     },
-    "node_modules/arr-union": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/assign-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/bytewise": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
-      "integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
-      "peer": true,
-      "dependencies": {
-        "bytewise-core": "^1.2.2",
-        "typewise": "^1.0.3"
-      }
-    },
-    "node_modules/bytewise-core": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
-      "integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
-      "peer": true,
-      "dependencies": {
-        "typewise-core": "^1.2"
-      }
-    },
     "node_modules/earcut": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.0.tgz",
-      "integrity": "sha512-41Fs7Q/PLq1SDbqjsgcY7GA42T0jvaCNGXgGtsNdvg+Yv8eIu06bxv4/PoREkZ9nMDNwnUSG9OFB9+yv8eKhDg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.1.tgz",
+      "integrity": "sha512-0l1/0gOjESMeQyYaK5IDiPNvFeu93Z/cO0TjZh9eZ1vyCtZnA7KMZ8rQggpsJHIbGSdrqYq9OhuveadOVHCshw==",
       "peer": true
-    },
-    "node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-      "peer": true,
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/geojson-vt": {
       "version": "4.0.2",
@@ -258,15 +196,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/get-value": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/gl-matrix": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
@@ -274,17 +203,17 @@
       "peer": true
     },
     "node_modules/global-prefix": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
-      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-4.0.0.tgz",
+      "integrity": "sha512-w0Uf9Y9/nyHinEk5vMJKRie+wa4kR5hmDbEhGGds/kG1PwGLLHKRoNMeJOyCQjjBkANlnScqgzcFwGHgmgLkVA==",
       "peer": true,
       "dependencies": {
-        "ini": "^1.3.5",
-        "kind-of": "^6.0.2",
-        "which": "^1.3.1"
+        "ini": "^4.1.3",
+        "kind-of": "^6.0.3",
+        "which": "^4.0.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=16"
       }
     },
     "node_modules/ieee754": {
@@ -308,45 +237,21 @@
       "peer": true
     },
     "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "peer": true
-    },
-    "node_modules/is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
       "peer": true,
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "peer": true,
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "peer": true
-    },
-    "node_modules/isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
       "peer": true,
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=16"
       }
     },
     "node_modules/json-stringify-pretty-compact": {
@@ -371,9 +276,9 @@
       }
     },
     "node_modules/maplibre-gl": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.5.2.tgz",
-      "integrity": "sha512-vlWL9EY2bSGg5FAt0mKPfYqlfX15uLW5D3kKv4Xjn54nIVn01MKdfUJMAVIr+8fXVqfSX6c095Iy5XnV+T76kQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.0.0.tgz",
+      "integrity": "sha512-WG8IYFK2gfJYXvWjlqg1yavo/YO/JlNkblAJMt19sjIafP5oJzTgXFiOLUIYkjtrv5pKiAWuSYsx4CD3ithJqw==",
       "peer": true,
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
@@ -383,17 +288,17 @@
         "@mapbox/unitbezier": "^0.0.1",
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^20.3.0",
-        "@types/geojson": "^7946.0.14",
+        "@maplibre/maplibre-gl-style-spec": "^22.0.1",
+        "@types/geojson": "^7946.0.15",
         "@types/geojson-vt": "3.2.5",
         "@types/mapbox__point-geometry": "^0.1.4",
         "@types/mapbox__vector-tile": "^1.3.4",
         "@types/pbf": "^3.0.5",
         "@types/supercluster": "^7.1.3",
-        "earcut": "^3.0.0",
+        "earcut": "^3.0.1",
         "geojson-vt": "^4.0.2",
         "gl-matrix": "^3.4.3",
-        "global-prefix": "^3.0.0",
+        "global-prefix": "^4.0.0",
         "kdbush": "^4.0.2",
         "murmurhash-js": "^1.0.0",
         "pbf": "^3.3.0",
@@ -481,93 +386,6 @@
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/set-value": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
-      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
-      "peer": true,
-      "dependencies": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sort-asc": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.2.0.tgz",
-      "integrity": "sha512-umMGhjPeHAI6YjABoSTrFp2zaBtXBej1a0yKkuMUyjjqu6FJsTF+JYwCswWDg+zJfk/5npWUUbd33HH/WLzpaA==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sort-desc": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.2.0.tgz",
-      "integrity": "sha512-NqZqyvL4VPW+RAxxXnB8gvE1kyikh8+pR+T+CXLksVRN9eiQqkQlPwqWYU0mF9Jm7UnctShlxLyAt1CaBOTL1w==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sort-object": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-3.0.3.tgz",
-      "integrity": "sha512-nK7WOY8jik6zaG9CRwZTaD5O7ETWDLZYMM12pqY8htll+7dYeqGfEUPcUBHOpSJg2vJOrvFIY2Dl5cX2ih1hAQ==",
-      "peer": true,
-      "dependencies": {
-        "bytewise": "^1.1.0",
-        "get-value": "^2.0.2",
-        "is-extendable": "^0.1.1",
-        "sort-asc": "^0.2.0",
-        "sort-desc": "^0.2.0",
-        "union-value": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/split-string": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-      "peer": true,
-      "dependencies": {
-        "extend-shallow": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/split-string/node_modules/extend-shallow": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
-      "peer": true,
-      "dependencies": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/split-string/node_modules/is-extendable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-      "peer": true,
-      "dependencies": {
-        "is-plain-object": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/supercluster": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
@@ -589,36 +407,6 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "peer": true
     },
-    "node_modules/typewise": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
-      "integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
-      "peer": true,
-      "dependencies": {
-        "typewise-core": "^1.2.0"
-      }
-    },
-    "node_modules/typewise-core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
-      "integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==",
-      "peer": true
-    },
-    "node_modules/union-value": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
-      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
-      "peer": true,
-      "dependencies": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/vt-pbf": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
@@ -631,15 +419,18 @@
       }
     },
     "node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
       "peer": true,
       "dependencies": {
-        "isexe": "^2.0.0"
+        "isexe": "^3.1.1"
       },
       "bin": {
-        "which": "bin/which"
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/zone.js": {

--- a/projects/ngx-maplibre-gl/package.json
+++ b/projects/ngx-maplibre-gl/package.json
@@ -22,7 +22,7 @@
   "peerDependencies": {
     "@angular/common": ">= 18.0.0",
     "@angular/core": ">= 18.0.0",
-    "maplibre-gl": ">= 4.5.2",
+    "maplibre-gl": ">= 5.0.0",
     "rxjs": ">= 7.8.1"
   }
 }

--- a/projects/ngx-maplibre-gl/src/lib/control/globe-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/globe-control.directive.ts
@@ -1,0 +1,42 @@
+import { Directive, afterNextRender, inject } from '@angular/core';
+import { GlobeControl } from 'maplibre-gl';
+import { MapService } from '../map/map.service';
+import { ControlComponent } from './control.component';
+
+/**
+ * `mglGlobe` - a globe control directive
+ *
+ * @category Directives
+ *
+ * @see [Globe](https://maplibre.org/ngx-maplibre-gl/demo/globe)
+ * @see [GlobeControl](https://maplibre.org/maplibre-gl-js/docs/API/classes/GlobeControl)
+ */
+@Directive({
+  selector: '[mglGlobe]',
+  standalone: true,
+})
+export class GlobeControlDirective {
+
+  private readonly mapService = inject(MapService);
+  private readonly controlComponent = inject<ControlComponent<GlobeControl>>(
+    ControlComponent,
+    { host: true }
+  );
+
+  constructor() {
+    afterNextRender(() => {
+      this.mapService.mapCreated$.subscribe(() => {
+        if (this.controlComponent.control) {
+          throw new Error('Another control is already set for this control');
+        }
+
+        this.controlComponent.control = new GlobeControl();
+
+        this.mapService.addControl(
+          this.controlComponent.control,
+          this.controlComponent.position()
+        );
+      });
+    });
+  }
+}

--- a/projects/ngx-maplibre-gl/src/lib/control/navigation-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/navigation-control.directive.ts
@@ -29,6 +29,8 @@ export class NavigationControlDirective {
   readonly showZoom = input<boolean>();
   /* Init inputs */
   readonly visualizePitch = input<boolean>();
+  /* Init inputs */
+  readonly visualizeRoll = input<boolean>();
 
   constructor() {
     afterNextRender(() => {
@@ -40,6 +42,7 @@ export class NavigationControlDirective {
           showCompass: this.showCompass(),
           showZoom: this.showZoom(),
           visualizePitch: this.visualizePitch(),
+          visualizeRoll: this.visualizeRoll(),
         });
         this.controlComponent.control = new NavigationControl(options);
         this.mapService.addControl(

--- a/projects/ngx-maplibre-gl/src/lib/map/map.component.spec.ts
+++ b/projects/ngx-maplibre-gl/src/lib/map/map.component.spec.ts
@@ -24,6 +24,7 @@ const getMapServiceStub = () =>
       'updateMaxPitch',
       'updateMinPitch',
       'destroyMap',
+      'clearMapElements'
     ],
     {
       mapCreated$: of(true),

--- a/projects/ngx-maplibre-gl/src/lib/map/map.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/map/map.component.ts
@@ -28,6 +28,7 @@ import type {
   MapWheelEvent,
   PointLike,
   TerrainSpecification,
+  ProjectionSpecification,
 } from 'maplibre-gl';
 import { MapService, type MovingOptions } from './map.service';
 import type { MapEvent, EventData } from './map.types';
@@ -184,10 +185,11 @@ export class MapComponent implements OnChanges, OnDestroy, MapEvent {
   /** Dynamic input */
   readonly renderWorldCopies = input<MapOptions['renderWorldCopies']>();
   /** Dynamic input */
-  readonly terrain = input<TerrainSpecification>();
-  /** Dynamic input */
   readonly elevation = input<MapOptions['elevation']>();
-
+  /** Dynamic input that is not part of the `MapOptions` object */
+  readonly terrain = input<TerrainSpecification>();
+  /** Dynamic input that is not part of the `MapOptions` object  */
+  readonly projection = input<ProjectionSpecification>();
 
   /** Added by ngx-mapbox-gl */
   readonly movingMethod = input<'jumpTo' | 'easeTo' | 'flyTo'>('flyTo');
@@ -347,7 +349,6 @@ export class MapComponent implements OnChanges, OnDestroy, MapEvent {
           fitBoundsOptions: this.fitBoundsOptions(),
           locale: this.locale,
           cooperativeGestures: this.cooperativeGestures(),
-          terrain: this.terrain(),
           cancelPendingTileRequestsWhileZooming: this.cancelPendingTileRequestsWhileZooming(),
           centerClampedToGround: this.centerClampedToGround(),
           elevation: this.elevation(),
@@ -357,7 +358,10 @@ export class MapComponent implements OnChanges, OnDestroy, MapEvent {
           pixelRatio: this.pixelRatio(),
           rollEnabled: this.rollEnabled(),
           transformCameraUpdate: this.transformCameraUpdate(),
-          validateStyle: this.validateStyle()
+          validateStyle: this.validateStyle(),
+
+          terrain: this.terrain(),
+          projection: this.projection(),
         },
         mapEvents: this,
       });
@@ -496,7 +500,10 @@ export class MapComponent implements OnChanges, OnDestroy, MapEvent {
       );
     }
     if (changes.terrain && !changes.terrain.isFirstChange()) {
-      this.mapService.updateTerrain(changes.terrain.currentValue);
+      this.mapService.setTerrain(changes.terrain.currentValue);
+    }
+    if (changes.projection && !changes.projection.isFirstChange()) {
+      this.mapService.setProjection(changes.projection.currentValue);
     }
     if (changes.elevation && !changes.elevation.isFirstChange()) {
       this.mapService.setCenterElevation(changes.elevation.currentValue);

--- a/projects/ngx-maplibre-gl/src/lib/map/map.service.ts
+++ b/projects/ngx-maplibre-gl/src/lib/map/map.service.ts
@@ -37,7 +37,8 @@ import {
   type QueryRenderedFeaturesOptions,
   type ControlPosition,
   type Subscription,
-  MapLayerEventType
+  type MapLayerEventType,
+  type ProjectionSpecification
 } from 'maplibre-gl';
 import { AsyncSubject } from 'rxjs';
 import type {
@@ -54,6 +55,7 @@ export interface SetupMap {
     pitch?: [number];
     zoom?: [number];
     terrain?: TerrainSpecification;
+    projection?: ProjectionSpecification;
   };
   mapEvents: MapEvent;
 }
@@ -116,9 +118,14 @@ export class MapService {
     this.mapCreated.next(undefined);
     this.mapCreated.complete();
 
-    if (options.mapOptions.terrain) {
+    if (options.mapOptions.terrain || options.mapOptions.projection) {
       this.mapInstance.on('load', () => {
-        this.updateTerrain(options.mapOptions.terrain!);
+        if (options.mapOptions.projection) {
+          this.setProjection(options.mapOptions.projection!);
+        }
+        if (options.mapOptions.terrain) {
+          this.setTerrain(options.mapOptions.terrain!);
+        }
       });
     }
   }
@@ -235,7 +242,13 @@ export class MapService {
     });
   }
 
-  updateTerrain(options: TerrainSpecification) {
+  setProjection(options: ProjectionSpecification) {
+    return this.zone.runOutsideAngular(() => {
+      this.mapInstance.setProjection(options);
+    });
+  }
+
+  setTerrain(options: TerrainSpecification) {
     return this.zone.runOutsideAngular(() => {
       this.mapInstance.setTerrain(options);
     });

--- a/projects/ngx-maplibre-gl/src/lib/map/map.service.ts
+++ b/projects/ngx-maplibre-gl/src/lib/map/map.service.ts
@@ -247,6 +247,12 @@ export class MapService {
     });
   }
 
+  setCenterElevation(elevation: number) {
+    return this.zone.runOutsideAngular(() => {
+      this.mapInstance.setCenterElevation(elevation);
+    });
+  }
+
   changeCanvasCursor(cursor: string) {
     const canvas = this.mapInstance.getCanvasContainer();
     canvas.style.cursor = cursor;
@@ -274,7 +280,8 @@ export class MapService {
     zoom?: number,
     center?: LngLatLike,
     bearing?: number,
-    pitch?: number
+    pitch?: number,
+    roll?: number
   ) {
     return this.zone.runOutsideAngular(() => {
       (this.mapInstance[movingMethod] as any)({
@@ -283,6 +290,7 @@ export class MapService {
         center: center != null ? center : this.mapInstance.getCenter(),
         bearing: bearing != null ? bearing : this.mapInstance.getBearing(),
         pitch: pitch != null ? pitch : this.mapInstance.getPitch(),
+        roll: roll != null ? roll : this.mapInstance.getRoll(),
       });
     });
   }

--- a/projects/ngx-maplibre-gl/src/public_api.ts
+++ b/projects/ngx-maplibre-gl/src/public_api.ts
@@ -26,6 +26,7 @@ export * from './lib/control/attribution-control.directive';
 export * from './lib/control/scale-control.directive';
 export * from './lib/markers-for-clusters/markers-for-clusters.component';
 export * from './lib/control/terrain-control.directive';
+export * from './lib/control/globe-control.directive';
 
 // Expose MapService for ngx-maplibre-gl extensions
 export * from './lib/map/map.service';

--- a/projects/showcase/src/app/demo/demo-index.component.ts
+++ b/projects/showcase/src/app/demo/demo-index.component.ts
@@ -33,7 +33,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { LayoutToolbarMenuComponent } from '../shared/layout/layout-toolbar-menu.component';
 
-type RoutesByCategory = { [P in Category]: Routes };
+type RoutesByCategory = { [key: string]: Routes };
 
 @Component({
   templateUrl: './demo-index.component.html',
@@ -62,7 +62,7 @@ export class DemoIndexComponent implements OnInit {
 
   routes: RoutesByCategory;
   originalRoutes: RoutesByCategory;
-  categories: Category[];
+  categories: string[];
   searchTerm: string;
   sidenavIsOpen = true;
   isEditMode = !!this.activatedRoute.snapshot.firstChild!.params.demoUrl;
@@ -79,15 +79,7 @@ export class DemoIndexComponent implements OnInit {
         )
       ))
     );
-    this.categories = [
-      Category.STYLES,
-      Category.LAYERS,
-      Category.SOURCES,
-      Category.USER_INTERACTION,
-      Category.CAMERA,
-      Category.CONTROLS_AND_OVERLAYS,
-      Category.TERRAIN,
-    ];
+    this.categories = Object.values(Category);
 
     afterNextRender(() => {
       this.scrollInToActiveExampleLink();

--- a/projects/showcase/src/app/demo/demo-index.component.ts
+++ b/projects/showcase/src/app/demo/demo-index.component.ts
@@ -22,7 +22,7 @@ import {
 import { cloneDeep, groupBy } from 'lodash-es';
 import { first } from 'rxjs/operators';
 import scrollIntoView from 'scroll-into-view-if-needed';
-import { Category, DEMO_ROUTES } from './routes';
+import { CATEGORIES, DEMO_ROUTES } from './routes';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatListModule } from '@angular/material/list';
 import { MatInputModule } from '@angular/material/input';
@@ -33,7 +33,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { LayoutToolbarMenuComponent } from '../shared/layout/layout-toolbar-menu.component';
 
-type RoutesByCategory = { [key: string]: Routes };
+interface RoutesByCategory { [key: string]: Routes }
 
 @Component({
   templateUrl: './demo-index.component.html',
@@ -79,7 +79,7 @@ export class DemoIndexComponent implements OnInit {
         )
       ))
     );
-    this.categories = Object.values(Category);
+    this.categories = Object.values(CATEGORIES);
 
     afterNextRender(() => {
       this.scrollInToActiveExampleLink();

--- a/projects/showcase/src/app/demo/examples/3d-buildings.component.ts
+++ b/projects/showcase/src/app/demo/examples/3d-buildings.component.ts
@@ -14,7 +14,7 @@ import { MapComponent, LayerComponent } from '@maplibre/ngx-maplibre-gl';
       [pitch]="45"
       [bearing]="-17.6"
       (mapLoad)="onLoad($event)"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       <mgl-layer
         id="3d-buildings"

--- a/projects/showcase/src/app/demo/examples/add-image-generated.component.ts
+++ b/projects/showcase/src/app/demo/examples/add-image-generated.component.ts
@@ -12,7 +12,7 @@ import {
       [style]="
         'https://api.maptiler.com/maps/streets/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL'
       "
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       <mgl-image
         id="gradient"

--- a/projects/showcase/src/app/demo/examples/add-image-missing-generated.component.ts
+++ b/projects/showcase/src/app/demo/examples/add-image-missing-generated.component.ts
@@ -14,7 +14,7 @@ import {
         'https://api.maptiler.com/maps/streets/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL'
       "
       (styleImageMissing)="generateImage($event)"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       @for (imageData of imagesData(); track imageData.id) {
       <mgl-image [id]="imageData.id" [data]="imageData"></mgl-image>

--- a/projects/showcase/src/app/demo/examples/add-image.component.ts
+++ b/projects/showcase/src/app/demo/examples/add-image.component.ts
@@ -12,7 +12,7 @@ import {
       [style]="
         'https://api.maptiler.com/maps/streets/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL'
       "
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       <mgl-image
         id="cat"

--- a/projects/showcase/src/app/demo/examples/attribution-position.component.ts
+++ b/projects/showcase/src/app/demo/examples/attribution-position.component.ts
@@ -15,7 +15,7 @@ import {
       [center]="[-77.04, 38.907]"
       [zoom]="[11.15]"
       [attributionControl]="false"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       <mgl-control mglAttribution position="top-left"></mgl-control>
     </mgl-map>

--- a/projects/showcase/src/app/demo/examples/center-on-symbol.component.ts
+++ b/projects/showcase/src/app/demo/examples/center-on-symbol.component.ts
@@ -18,7 +18,7 @@ import {
       [center]="center"
       [cursorStyle]="cursorStyle"
       (mapLoad)="map = $event"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       <mgl-geojson-source id="symbols-source">
         @for (geometry of geometries; track geometry) {

--- a/projects/showcase/src/app/demo/examples/cluster-html.component.ts
+++ b/projects/showcase/src/app/demo/examples/cluster-html.component.ts
@@ -132,7 +132,7 @@ const COLORS = ['#fed976', '#feb24c', '#fd8d3c', '#fc4e2a', '#e31a1c'];
       "
       [zoom]="[0.3]"
       [center]="[0, 20]"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       <mgl-geojson-source
         id="earthquakes"

--- a/projects/showcase/src/app/demo/examples/cluster.component.ts
+++ b/projects/showcase/src/app/demo/examples/cluster.component.ts
@@ -14,7 +14,7 @@ import {
       "
       [zoom]="[3]"
       [center]="[-103.59179687498357, 40.66995747013945]"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       @if (earthquakes) {
         <mgl-geojson-source

--- a/projects/showcase/src/app/demo/examples/custom-attribution.component.ts
+++ b/projects/showcase/src/app/demo/examples/custom-attribution.component.ts
@@ -15,7 +15,7 @@ import {
       [center]="[-77.04, 38.907]"
       [zoom]="[11.15]"
       [attributionControl]="false"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       <mgl-control
         mglAttribution

--- a/projects/showcase/src/app/demo/examples/custom-locale.component.ts
+++ b/projects/showcase/src/app/demo/examples/custom-locale.component.ts
@@ -18,7 +18,7 @@ import {
       [center]="[36.235656, 50.00387]"
       [zoom]="[11.15]"
       [locale]="locale"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       <mgl-control mglFullscreen position="top-left"></mgl-control>
       <mgl-control mglGeolocate position="top-left"></mgl-control>

--- a/projects/showcase/src/app/demo/examples/custom-marker-icons.component.ts
+++ b/projects/showcase/src/app/demo/examples/custom-marker-icons.component.ts
@@ -11,7 +11,7 @@ import { NgStyle } from '@angular/common';
       "
       [zoom]="[5]"
       [center]="[-65.017, -16.457]"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       @for (feature of geojson.features; track feature) {
         <mgl-marker [feature]="feature">

--- a/projects/showcase/src/app/demo/examples/custom-style-id.component.ts
+++ b/projects/showcase/src/app/demo/examples/custom-style-id.component.ts
@@ -10,7 +10,7 @@ import { MapComponent } from '@maplibre/ngx-maplibre-gl';
       "
       [zoom]="[3]"
       [center]="[-77.38, 39]"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
     </mgl-map>
   `,

--- a/projects/showcase/src/app/demo/examples/display-map.component.ts
+++ b/projects/showcase/src/app/demo/examples/display-map.component.ts
@@ -10,7 +10,7 @@ import { MapComponent } from '@maplibre/ngx-maplibre-gl';
       "
       [zoom]="[9]"
       [center]="[-74.5, 40]"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     ></mgl-map>
   `,
   styleUrls: ['./examples.css'],

--- a/projects/showcase/src/app/demo/examples/drag-a-marker.component.ts
+++ b/projects/showcase/src/app/demo/examples/drag-a-marker.component.ts
@@ -16,7 +16,7 @@ import {
       "
       [zoom]="[2]"
       [center]="[0, 0]"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       <mgl-marker
         [lngLat]="[0, 0]"

--- a/projects/showcase/src/app/demo/examples/fullscreen.component.ts
+++ b/projects/showcase/src/app/demo/examples/fullscreen.component.ts
@@ -14,7 +14,7 @@ import {
       "
       [zoom]="[13]"
       [center]="[11.255, 43.77]"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       <mgl-control mglFullscreen></mgl-control>
     </mgl-map>

--- a/projects/showcase/src/app/demo/examples/geojson-line.component.ts
+++ b/projects/showcase/src/app/demo/examples/geojson-line.component.ts
@@ -10,7 +10,7 @@ import { MapComponent, LayerComponent } from '@maplibre/ngx-maplibre-gl';
       "
       [zoom]="[15]"
       [center]="[-122.486052, 37.830348]"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       <mgl-layer
         id="route"

--- a/projects/showcase/src/app/demo/examples/globe.component.ts
+++ b/projects/showcase/src/app/demo/examples/globe.component.ts
@@ -1,0 +1,26 @@
+import { Component } from '@angular/core';
+import {
+  MapComponent,
+  GlobeControlDirective,
+  ControlComponent,
+} from '@maplibre/ngx-maplibre-gl';
+import { NgStyle } from '@angular/common';
+
+@Component({
+  selector: 'showcase-demo',
+  template: `
+    <mgl-map
+      [style]="'https://demotiles.maplibre.org/style.json'"
+      [zoom]="[2]"
+      [center]="[0, 0]"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
+      [projection]="{type: 'globe'}"
+    >
+       <mgl-control mglGlobe position="top-right"></mgl-control>
+    </mgl-map>
+  `,
+  styleUrls: ['./examples.css'],
+  standalone: true,
+  imports: [MapComponent, NgStyle, ControlComponent, GlobeControlDirective],
+})
+export class GlobeComponent {}

--- a/projects/showcase/src/app/demo/examples/heatmap.component.ts
+++ b/projects/showcase/src/app/demo/examples/heatmap.component.ts
@@ -15,7 +15,7 @@ import {
       "
       [zoom]="[3]"
       [center]="[-103.59179687498357, 40.66995747013945]"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       @if (earthquakes) {
         <mgl-geojson-source

--- a/projects/showcase/src/app/demo/examples/hover-styles.component.ts
+++ b/projects/showcase/src/app/demo/examples/hover-styles.component.ts
@@ -14,7 +14,7 @@ import {
       "
       [zoom]="[2]"
       [center]="[-100.486052, 37.830348]"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       <mgl-geojson-source
         id="states"

--- a/projects/showcase/src/app/demo/examples/interactive-false.component.ts
+++ b/projects/showcase/src/app/demo/examples/interactive-false.component.ts
@@ -11,7 +11,7 @@ import { MapComponent } from '@maplibre/ngx-maplibre-gl';
       [zoom]="[9]"
       [center]="[-74.5, 40]"
       [interactive]="false"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
     </mgl-map>
   `,

--- a/projects/showcase/src/app/demo/examples/language-switch.component.ts
+++ b/projects/showcase/src/app/demo/examples/language-switch.component.ts
@@ -13,7 +13,7 @@ import { Map } from 'maplibre-gl';
       [zoom]="[2.9]"
       [center]="[16.05, 48]"
       (mapLoad)="mapLoaded($event)"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       <mgl-control>
         <button

--- a/projects/showcase/src/app/demo/examples/live-update-feature.component.ts
+++ b/projects/showcase/src/app/demo/examples/live-update-feature.component.ts
@@ -18,7 +18,7 @@ import data from './hike.geo.json';
       [centerWithPanTo]="true"
       [pitch]="pitch"
       movingMethod="jumpTo"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       @if (data) {
         <mgl-geojson-source id="trace" [data]="data"> </mgl-geojson-source>

--- a/projects/showcase/src/app/demo/examples/live-update-image-srource.component.ts
+++ b/projects/showcase/src/app/demo/examples/live-update-image-srource.component.ts
@@ -22,7 +22,7 @@ import data from './hike.geo.json';
       [center]="center"
       [zoom]="[14]"
       movingMethod="jumpTo"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       <mgl-image-source
         id="test_source"

--- a/projects/showcase/src/app/demo/examples/locate-user.component.ts
+++ b/projects/showcase/src/app/demo/examples/locate-user.component.ts
@@ -12,7 +12,7 @@ import {
       [style]="
         'https://api.maptiler.com/maps/streets/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL'
       "
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       <mgl-control
         mglGeolocate

--- a/projects/showcase/src/app/demo/examples/marker-alignment.component.ts
+++ b/projects/showcase/src/app/demo/examples/marker-alignment.component.ts
@@ -14,7 +14,7 @@ import { MapComponent, MarkerComponent } from '@maplibre/ngx-maplibre-gl';
       [bearing]="[bearing]"
       [zoom]="[17]"
       [center]="[4.577979, 51.038189]"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       <mgl-marker
         [lngLat]="[4.577979, 51.03816]"

--- a/projects/showcase/src/app/demo/examples/navigation.component.ts
+++ b/projects/showcase/src/app/demo/examples/navigation.component.ts
@@ -14,7 +14,7 @@ import {
       "
       [zoom]="[9]"
       [center]="[-74.5, 40]"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       <mgl-control mglNavigation></mgl-control>
     </mgl-map>

--- a/projects/showcase/src/app/demo/examples/ngx-cluster-html.component.ts
+++ b/projects/showcase/src/app/demo/examples/ngx-cluster-html.component.ts
@@ -93,7 +93,7 @@ export class ClusterPopupComponent implements OnChanges {
       "
       [zoom]="[3]"
       [center]="[-103.59179687498357, 40.66995747013945]"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       @if (earthquakes(); as earthquakesValue) {
       <mgl-geojson-source

--- a/projects/showcase/src/app/demo/examples/ngx-custom-control.component.ts
+++ b/projects/showcase/src/app/demo/examples/ngx-custom-control.component.ts
@@ -18,7 +18,7 @@ import {
       [style]="
         'https://api.maptiler.com/maps/streets/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL'
       "
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       @if (visible) {
         <mgl-control>

--- a/projects/showcase/src/app/demo/examples/ngx-custom-marker-icons.component.ts
+++ b/projects/showcase/src/app/demo/examples/ngx-custom-marker-icons.component.ts
@@ -10,7 +10,7 @@ import { MapComponent, MarkerComponent } from '@maplibre/ngx-maplibre-gl';
       "
       [zoom]="[5]"
       [center]="[-65.017, -16.457]"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       <mgl-marker [lngLat]="[-66.324462890625, -16.024695711685304]">
         <div

--- a/projects/showcase/src/app/demo/examples/ngx-drag-a-point.component.ts
+++ b/projects/showcase/src/app/demo/examples/ngx-drag-a-point.component.ts
@@ -19,7 +19,7 @@ import {
       "
       [zoom]="[2]"
       [center]="[0, 0]"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       <mgl-geojson-source id="point">
         <mgl-feature

--- a/projects/showcase/src/app/demo/examples/ngx-geojson-line.component.ts
+++ b/projects/showcase/src/app/demo/examples/ngx-geojson-line.component.ts
@@ -15,7 +15,7 @@ import {
       "
       [zoom]="[15]"
       [center]="[-122.486052, 37.830348]"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       <mgl-geojson-source id="oneline">
         <mgl-feature [geometry]="geometry"> </mgl-feature>

--- a/projects/showcase/src/app/demo/examples/ngx-marker-rotate.component.ts
+++ b/projects/showcase/src/app/demo/examples/ngx-marker-rotate.component.ts
@@ -10,7 +10,7 @@ import { MapComponent, MarkerComponent } from '@maplibre/ngx-maplibre-gl';
       "
       [zoom]="[5]"
       [center]="[144.946457, -37.840935]"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       <mgl-marker [lngLat]="[144.946457, -38.440935]" [rotation]="180"></mgl-marker>
     </mgl-map>

--- a/projects/showcase/src/app/demo/examples/ngx-scale-control.component.ts
+++ b/projects/showcase/src/app/demo/examples/ngx-scale-control.component.ts
@@ -12,7 +12,7 @@ import {
       [style]="
         'https://api.maptiler.com/maps/streets/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL'
       "
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       <mgl-control mglScale unit="imperial" position="top-right"></mgl-control>
     </mgl-map>

--- a/projects/showcase/src/app/demo/examples/ngx-terrain-control.component.ts
+++ b/projects/showcase/src/app/demo/examples/ngx-terrain-control.component.ts
@@ -17,7 +17,7 @@ import {
       [zoom]="[12]"
       [center]="[11.39085, 47.27574]"
       [pitch]="52"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       <mgl-raster-dem-source
         id="terrainSource"

--- a/projects/showcase/src/app/demo/examples/polygon-popup-on-click.component.ts
+++ b/projects/showcase/src/app/demo/examples/polygon-popup-on-click.component.ts
@@ -18,7 +18,7 @@ import {
       [center]="[-100.04, 38.907]"
       [cursorStyle]="cursorStyle"
       (mapClick)="onMapClick()"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       <mgl-layer
         id="states-layer"

--- a/projects/showcase/src/app/demo/examples/popup-on-click.component.ts
+++ b/projects/showcase/src/app/demo/examples/popup-on-click.component.ts
@@ -17,7 +17,7 @@ import {
       [zoom]="[11.15]"
       [center]="[-77.04, 38.907]"
       [cursorStyle]="cursorStyle"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       <mgl-geojson-source id="points" [data]="points"></mgl-geojson-source>
       <mgl-layer

--- a/projects/showcase/src/app/demo/examples/popup.component.ts
+++ b/projects/showcase/src/app/demo/examples/popup.component.ts
@@ -13,7 +13,7 @@ import {
       "
       [zoom]="[3]"
       [center]="[-96, 37.8]"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
       data-cy="mgl-map"
     >
       <mgl-popup

--- a/projects/showcase/src/app/demo/examples/satellite-map.component.ts
+++ b/projects/showcase/src/app/demo/examples/satellite-map.component.ts
@@ -32,7 +32,7 @@ import { MapComponent } from '@maplibre/ngx-maplibre-gl';
       }"
       [zoom]="[9]"
       [center]="[137.9150899566626, 36.25956997955441]"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
     </mgl-map>
   `,

--- a/projects/showcase/src/app/demo/examples/set-popup.component.ts
+++ b/projects/showcase/src/app/demo/examples/set-popup.component.ts
@@ -13,7 +13,7 @@ import { NgStyle } from '@angular/common';
       [style]="'https://demotiles.maplibre.org/style.json'"
       [zoom]="[15]"
       [center]="[-77.0353, 38.8895]"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       <mgl-marker #myMarker [lngLat]="[-77.0353, 38.8895]">
         <div

--- a/projects/showcase/src/app/demo/examples/set-style.component.ts
+++ b/projects/showcase/src/app/demo/examples/set-style.component.ts
@@ -15,7 +15,7 @@ import {
       [style]="style"
       [zoom]="[13]"
       [center]="[4.899, 52.372]"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
       data-cy="mgl-map"
     >
     </mgl-map>

--- a/projects/showcase/src/app/demo/examples/terrain-map-style.component.ts
+++ b/projects/showcase/src/app/demo/examples/terrain-map-style.component.ts
@@ -34,7 +34,7 @@ import { MapComponent } from '@maplibre/ngx-maplibre-gl';
       [zoom]="[12]"
       [center]="[11.39085, 47.27574]"
       [pitch]="52"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
     </mgl-map>
   `,

--- a/projects/showcase/src/app/demo/examples/terrain-map.component.ts
+++ b/projects/showcase/src/app/demo/examples/terrain-map.component.ts
@@ -14,7 +14,7 @@ import {
       [center]="[11.39085, 47.27574]"
       [pitch]="52"
       [terrain]="terrainSpec"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       <mgl-raster-dem-source
         id="terrainSource"

--- a/projects/showcase/src/app/demo/examples/toggle-layers.component.ts
+++ b/projects/showcase/src/app/demo/examples/toggle-layers.component.ts
@@ -16,7 +16,7 @@ import type { LayerSpecification } from 'maplibre-gl';
       "
       [zoom]="[3]"
       [center]="[-71.97722138410576, -13.517379300798098]"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       <mgl-vector-source
         id="countries"

--- a/projects/showcase/src/app/demo/examples/zoomto-linestring.component.ts
+++ b/projects/showcase/src/app/demo/examples/zoomto-linestring.component.ts
@@ -18,7 +18,7 @@ import { LngLatBounds } from 'maplibre-gl';
       [fitBoundsOptions]="{
         padding: 20
       }"
-      [preserveDrawingBuffer]="true"
+      [canvasContextAttributes]="{preserveDrawingBuffer: true}"
     >
       <mgl-control>
         <button

--- a/projects/showcase/src/app/demo/routes.ts
+++ b/projects/showcase/src/app/demo/routes.ts
@@ -1,15 +1,15 @@
 import { Routes } from '@angular/router';
 import { StackblitzEditGuard } from './stackblitz-edit/stackblitz-edit-guard.service';
 
-export const Category = {
-  STYLES: 'Styles',
-  LAYERS: 'Layers',
-  SOURCES: 'Sources',
-  USER_INTERACTION: 'User interaction',
-  CAMERA: 'Camera',
-  CONTROLS_AND_OVERLAYS: 'Controls and overlays',
-  TERRAIN: '3D Terrain',
-  GLOBE: 'Globe'
+export const CATEGORIES = {
+  styles: 'Styles',
+  layers: 'Layers',
+  sources: 'Sources',
+  unserInteraction: 'User interaction',
+  camera: 'Camera',
+  constrolsAndOverlays: 'Controls and overlays',
+  terrain: '3D Terrain',
+  globe: 'Globe'
 }
 
 export const DEMO_ROUTES: Routes = [
@@ -32,7 +32,7 @@ export const DEMO_ROUTES: Routes = [
           import('./examples/display-map.component').then(
             (m) => m.DisplayMapComponent
           ),
-        data: { label: 'Display a map', cat: Category.STYLES },
+        data: { label: 'Display a map', cat: CATEGORIES.styles },
       },
       {
         path: 'custom-style-id',
@@ -42,7 +42,7 @@ export const DEMO_ROUTES: Routes = [
           ),
         data: {
           label: 'Display a map with a custom style',
-          cat: Category.STYLES,
+          cat: CATEGORIES.styles,
         },
       },
       {
@@ -51,7 +51,7 @@ export const DEMO_ROUTES: Routes = [
           import('./examples/set-style.component').then(
             (m) => m.SetStyleComponent
           ),
-        data: { label: 'Change a map\'s style', cat: Category.STYLES },
+        data: { label: 'Change a map\'s style', cat: CATEGORIES.styles },
       },
       {
         path: 'satellite-map',
@@ -59,7 +59,7 @@ export const DEMO_ROUTES: Routes = [
           import('./examples/satellite-map.component').then(
             (m) => m.SatelliteMapComponent
           ),
-        data: { label: 'Display a satellite map', cat: Category.STYLES },
+        data: { label: 'Display a satellite map', cat: CATEGORIES.styles },
       },
       {
         path: 'add-image-generated',
@@ -69,7 +69,7 @@ export const DEMO_ROUTES: Routes = [
           ),
         data: {
           label: 'Add a generated icon to the map',
-          cat: Category.LAYERS,
+          cat: CATEGORIES.layers,
         },
       },
       {
@@ -78,7 +78,7 @@ export const DEMO_ROUTES: Routes = [
           import('./examples/add-image.component').then(
             (m) => m.AddImageComponent
           ),
-        data: { label: 'Add an icon to the map', cat: Category.LAYERS },
+        data: { label: 'Add an icon to the map', cat: CATEGORIES.layers },
       },
       {
         path: 'toggle-layers',
@@ -86,7 +86,7 @@ export const DEMO_ROUTES: Routes = [
           import('./examples/toggle-layers.component').then(
             (m) => m.ToggleLayersComponent
           ),
-        data: { label: 'Show and hide layers', cat: Category.LAYERS },
+        data: { label: 'Show and hide layers', cat: CATEGORIES.layers },
       },
       {
         path: '3d-buildings',
@@ -94,7 +94,7 @@ export const DEMO_ROUTES: Routes = [
           import('./examples/3d-buildings.component').then(
             (m) => m.Display3dBuildingsComponent
           ),
-        data: { label: 'Display 3d buildings', cat: Category.LAYERS },
+        data: { label: 'Display 3d buildings', cat: CATEGORIES.layers },
       },
       {
         path: 'cluster',
@@ -102,7 +102,7 @@ export const DEMO_ROUTES: Routes = [
           import('./examples/cluster.component').then(
             (m) => m.ClusterComponent
           ),
-        data: { label: 'Create and style clusters', cat: Category.LAYERS },
+        data: { label: 'Create and style clusters', cat: CATEGORIES.layers },
       },
       {
         path: 'heatmap',
@@ -110,7 +110,7 @@ export const DEMO_ROUTES: Routes = [
           import('./examples/heatmap.component').then(
             (m) => m.HeatMapComponent
           ),
-        data: { label: 'Create a heatmap layer', cat: Category.LAYERS },
+        data: { label: 'Create a heatmap layer', cat: CATEGORIES.layers },
       },
       {
         path: 'geojson-line',
@@ -118,7 +118,7 @@ export const DEMO_ROUTES: Routes = [
           import('./examples/geojson-line.component').then(
             (m) => m.GeoJSONLineComponent
           ),
-        data: { label: 'Add a GeoJSON line', cat: Category.LAYERS },
+        data: { label: 'Add a GeoJSON line', cat: CATEGORIES.layers },
       },
       {
         path: 'ngx-geojson-line',
@@ -126,7 +126,7 @@ export const DEMO_ROUTES: Routes = [
           import('./examples/ngx-geojson-line.component').then(
             (m) => m.NgxGeoJSONLineComponent
           ),
-        data: { label: '[NGX] Add a GeoJSON line', cat: Category.LAYERS },
+        data: { label: '[NGX] Add a GeoJSON line', cat: CATEGORIES.layers },
       },
       {
         path: 'custom-marker-icons',
@@ -136,7 +136,7 @@ export const DEMO_ROUTES: Routes = [
           ),
         data: {
           label: 'Add custom icons with Markers',
-          cat: Category.CONTROLS_AND_OVERLAYS,
+          cat: CATEGORIES.constrolsAndOverlays,
         },
       },
       {
@@ -147,7 +147,7 @@ export const DEMO_ROUTES: Routes = [
           ),
         data: {
           label: '[NGX] Add custom icons with Markers',
-          cat: Category.CONTROLS_AND_OVERLAYS,
+          cat: CATEGORIES.constrolsAndOverlays,
         },
       },
       {
@@ -158,7 +158,7 @@ export const DEMO_ROUTES: Routes = [
           ),
         data: {
           label: '[NGX] Add marker and rotate it',
-          cat: Category.CONTROLS_AND_OVERLAYS,
+          cat: CATEGORIES.constrolsAndOverlays,
         },
       },
       {
@@ -167,7 +167,7 @@ export const DEMO_ROUTES: Routes = [
           import('./examples/live-update-feature.component').then(
             (m) => m.LiveUpdateFeatureComponent
           ),
-        data: { label: 'Update a feature in realtime', cat: Category.SOURCES },
+        data: { label: 'Update a feature in realtime', cat: CATEGORIES.sources },
       },
       {
         path: 'live-update-image-source',
@@ -177,14 +177,14 @@ export const DEMO_ROUTES: Routes = [
           ),
         data: {
           label: 'Update an image source in realtime',
-          cat: Category.SOURCES,
+          cat: CATEGORIES.sources,
         },
       },
       {
         path: 'popup',
         loadComponent: () =>
           import('./examples/popup.component').then((m) => m.PopupComponent),
-        data: { label: 'Display a popup', cat: Category.CONTROLS_AND_OVERLAYS },
+        data: { label: 'Display a popup', cat: CATEGORIES.constrolsAndOverlays },
       },
       {
         path: 'set-popup',
@@ -194,7 +194,7 @@ export const DEMO_ROUTES: Routes = [
           ),
         data: {
           label: 'Attach a popup to a marker instance',
-          cat: Category.CONTROLS_AND_OVERLAYS,
+          cat: CATEGORIES.constrolsAndOverlays,
         },
       },
       {
@@ -205,7 +205,7 @@ export const DEMO_ROUTES: Routes = [
           ),
         data: {
           label: 'View a fullscreen map',
-          cat: Category.CONTROLS_AND_OVERLAYS,
+          cat: CATEGORIES.constrolsAndOverlays,
         },
       },
       {
@@ -216,7 +216,7 @@ export const DEMO_ROUTES: Routes = [
           ),
         data: {
           label: 'Display map navigation controls',
-          cat: Category.CONTROLS_AND_OVERLAYS,
+          cat: CATEGORIES.constrolsAndOverlays,
         },
       },
       {
@@ -225,7 +225,7 @@ export const DEMO_ROUTES: Routes = [
           import('./examples/locate-user.component').then(
             (m) => m.LocateUserComponent
           ),
-        data: { label: 'Locate the user', cat: Category.CONTROLS_AND_OVERLAYS },
+        data: { label: 'Locate the user', cat: CATEGORIES.constrolsAndOverlays },
       },
       {
         path: 'attribution-position',
@@ -235,7 +235,7 @@ export const DEMO_ROUTES: Routes = [
           ),
         data: {
           label: 'Change the default position for attribution',
-          cat: Category.CONTROLS_AND_OVERLAYS,
+          cat: CATEGORIES.constrolsAndOverlays,
         },
       },
       {
@@ -246,7 +246,7 @@ export const DEMO_ROUTES: Routes = [
           ),
         data: {
           label: '[NGX] Show scale information',
-          cat: Category.CONTROLS_AND_OVERLAYS,
+          cat: CATEGORIES.constrolsAndOverlays,
         },
       },
       {
@@ -257,7 +257,7 @@ export const DEMO_ROUTES: Routes = [
           ),
         data: {
           label: '[NGX] Add a custom control',
-          cat: Category.CONTROLS_AND_OVERLAYS,
+          cat: CATEGORIES.constrolsAndOverlays,
         },
       },
       {
@@ -268,7 +268,7 @@ export const DEMO_ROUTES: Routes = [
           ),
         data: {
           label: 'Display a non-interactive map',
-          cat: Category.USER_INTERACTION,
+          cat: CATEGORIES.unserInteraction,
         },
       },
       {
@@ -279,7 +279,7 @@ export const DEMO_ROUTES: Routes = [
           ),
         data: {
           label: 'Change a map\'s language',
-          cat: Category.USER_INTERACTION,
+          cat: CATEGORIES.unserInteraction,
         },
       },
       {
@@ -290,7 +290,7 @@ export const DEMO_ROUTES: Routes = [
           ),
         data: {
           label: 'Center the map on a clicked symbol',
-          cat: Category.USER_INTERACTION,
+          cat: CATEGORIES.unserInteraction,
         },
       },
       {
@@ -301,7 +301,7 @@ export const DEMO_ROUTES: Routes = [
           ),
         data: {
           label: '[NGX] Create a draggable point',
-          cat: Category.USER_INTERACTION,
+          cat: CATEGORIES.unserInteraction,
         },
       },
       {
@@ -312,7 +312,7 @@ export const DEMO_ROUTES: Routes = [
           ),
         data: {
           label: 'Create a draggable marker',
-          cat: Category.USER_INTERACTION,
+          cat: CATEGORIES.unserInteraction,
         },
       },
       {
@@ -323,7 +323,7 @@ export const DEMO_ROUTES: Routes = [
           ),
         data: {
           label: 'Create a hover effect',
-          cat: Category.USER_INTERACTION,
+          cat: CATEGORIES.unserInteraction,
         },
       },
       {
@@ -334,7 +334,7 @@ export const DEMO_ROUTES: Routes = [
           ),
         data: {
           label: 'Display a popup on click',
-          cat: Category.CONTROLS_AND_OVERLAYS,
+          cat: CATEGORIES.constrolsAndOverlays,
         },
       },
       {
@@ -345,7 +345,7 @@ export const DEMO_ROUTES: Routes = [
           ),
         data: {
           label: 'Fit to the bounds of a LineString',
-          cat: Category.USER_INTERACTION,
+          cat: CATEGORIES.unserInteraction,
         },
       },
       {
@@ -356,7 +356,7 @@ export const DEMO_ROUTES: Routes = [
           ),
         data: {
           label: 'Display HTML clusters with custom properties',
-          cat: Category.LAYERS,
+          cat: CATEGORIES.layers,
         },
       },
       {
@@ -367,7 +367,7 @@ export const DEMO_ROUTES: Routes = [
           ),
         data: {
           label: '[NGX] Display HTML clusters with custom properties',
-          cat: Category.LAYERS,
+          cat: CATEGORIES.layers,
         },
       },
       {
@@ -378,7 +378,7 @@ export const DEMO_ROUTES: Routes = [
           ),
         data: {
           label: 'Show polygon information on click',
-          cat: Category.CONTROLS_AND_OVERLAYS,
+          cat: CATEGORIES.constrolsAndOverlays,
         },
       },
       {
@@ -389,7 +389,7 @@ export const DEMO_ROUTES: Routes = [
           ),
         data: {
           label: 'Generate and add a missing icon to the map',
-          cat: Category.STYLES,
+          cat: CATEGORIES.styles,
         },
       },
       {
@@ -400,7 +400,7 @@ export const DEMO_ROUTES: Routes = [
           ),
         data: {
           label: 'Add custom attributions',
-          cat: Category.CONTROLS_AND_OVERLAYS,
+          cat: CATEGORIES.constrolsAndOverlays,
         },
       },
       {
@@ -411,7 +411,7 @@ export const DEMO_ROUTES: Routes = [
           ),
         data: {
           label: 'Add custom localization for controls',
-          cat: Category.CONTROLS_AND_OVERLAYS,
+          cat: CATEGORIES.constrolsAndOverlays,
         },
       },
       {
@@ -420,7 +420,7 @@ export const DEMO_ROUTES: Routes = [
           import('./examples/marker-alignment.component').then(
             (m) => m.MarkerAlignmentComponent
           ),
-        data: { label: 'Marker alignment options', cat: Category.CAMERA },
+        data: { label: 'Marker alignment options', cat: CATEGORIES.camera },
       },
       {
         path: 'terrain-style',
@@ -430,7 +430,7 @@ export const DEMO_ROUTES: Routes = [
           ),
         data: {
           label: 'Initialize 3D Terrain using style',
-          cat: Category.TERRAIN,
+          cat: CATEGORIES.terrain,
         },
       },
       {
@@ -441,7 +441,7 @@ export const DEMO_ROUTES: Routes = [
           ),
         data: {
           label: 'Terrain Control',
-          cat: Category.TERRAIN,
+          cat: CATEGORIES.terrain,
         },
       },
       {
@@ -452,7 +452,7 @@ export const DEMO_ROUTES: Routes = [
           ),
         data: {
           label: '[NGX] Initialize 3D Terrain declaratively',
-          cat: Category.TERRAIN,
+          cat: CATEGORIES.terrain,
         },
       },
       {
@@ -463,7 +463,7 @@ export const DEMO_ROUTES: Routes = [
           ),
         data: {
           label: '[NGX] Initialize Globe Projection declaratively',
-          cat: Category.GLOBE,
+          cat: CATEGORIES.globe,
         },
       },
       { path: '**', redirectTo: 'display-map' },

--- a/projects/showcase/src/app/demo/routes.ts
+++ b/projects/showcase/src/app/demo/routes.ts
@@ -1,14 +1,15 @@
 import { Routes } from '@angular/router';
 import { StackblitzEditGuard } from './stackblitz-edit/stackblitz-edit-guard.service';
 
-export enum Category {
-  STYLES = 'Styles',
-  LAYERS = 'Layers',
-  SOURCES = 'Sources',
-  USER_INTERACTION = 'User interaction',
-  CAMERA = 'Camera',
-  CONTROLS_AND_OVERLAYS = 'Controls and overlays',
-  TERRAIN = '3D Terrain',
+export const Category = {
+  STYLES: 'Styles',
+  LAYERS: 'Layers',
+  SOURCES: 'Sources',
+  USER_INTERACTION: 'User interaction',
+  CAMERA: 'Camera',
+  CONTROLS_AND_OVERLAYS: 'Controls and overlays',
+  TERRAIN: '3D Terrain',
+  GLOBE: 'Globe'
 }
 
 export const DEMO_ROUTES: Routes = [
@@ -452,6 +453,17 @@ export const DEMO_ROUTES: Routes = [
         data: {
           label: '[NGX] Initialize 3D Terrain declaratively',
           cat: Category.TERRAIN,
+        },
+      },
+      {
+        path: 'globe',
+        loadComponent: () =>
+          import('./examples/globe.component').then(
+            (m) => m.GlobeComponent
+          ),
+        data: {
+          label: '[NGX] Initialize Globe Projection declaratively',
+          cat: Category.GLOBE,
         },
       },
       { path: '**', redirectTo: 'display-map' },


### PR DESCRIPTION
This add some missing attributes from the map options object and the navigation control.
The main changes are in the preserveDrawingBuffer, which was moved to an internal object.
Added projection settings as well.
Removed some noise in the console log of the unit-tests.
Added globe control directive and globe example.
