### PR TITLE
Change interface to type using eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,7 @@
         "plugin:@typescript-eslint/recommended"
       ],
       "rules": {
-        "@typescript-eslint/consistent-type-definitions": "error",
+        "@typescript-eslint/consistent-type-definitions": ["error", "type"],
         "@typescript-eslint/dot-notation": "off",
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-empty-function": "off",

--- a/projects/ngx-maplibre-gl/src/lib/map/map.service.ts
+++ b/projects/ngx-maplibre-gl/src/lib/map/map.service.ts
@@ -49,7 +49,7 @@ import type {
 } from './map.types';
 import { keepAvailableObjectValues } from '../shared/utils/functions/object.fn';
 
-export interface SetupMap {
+export type SetupMap = {
   mapOptions: Omit<MapOptions, 'bearing' | 'pitch' | 'zoom'> & {
     bearing?: [number];
     pitch?: [number];
@@ -60,12 +60,12 @@ export interface SetupMap {
   mapEvents: MapEvent;
 }
 
-export interface SetupLayer {
+export type SetupLayer = {
   layerOptions: LayerSpecification;
   layerEvents: LayerEvents;
 }
 
-export interface SetupPopup {
+export type SetupPopup = {
   popupOptions: PopupOptions;
   popupEvents: {
     popupOpen: OutputEmitterRef<void>;
@@ -73,16 +73,13 @@ export interface SetupPopup {
   };
 }
 
-/**
- * @private
- */
-export interface SetupMarkerOptions extends MarkerOptions {
+export type SetupMarkerOptions = {
   element: HTMLElement;
   feature?: GeoJSON.Feature<GeoJSON.Point>;
   lngLat?: LngLatLike;
-}
+} & MarkerOptions
 
-export interface SetupMarker {
+export type SetupMarker = {
   markersOptions: SetupMarkerOptions;
   markersEvents: {
     markerDragStart: OutputEmitterRef<Marker>;

--- a/projects/ngx-maplibre-gl/src/lib/map/map.types.ts
+++ b/projects/ngx-maplibre-gl/src/lib/map/map.types.ts
@@ -16,11 +16,9 @@ import type {
   MapWheelEvent,
 } from 'maplibre-gl';
 
-export interface EventData {
-  [key: string]: any;
-}
+export type EventData = Record<string, any>;
 
-export interface MapEvent {
+export type MapEvent = {
   mapResize: OutputEmitterRef<MapLibreEvent & EventData>;
   mapRemove: OutputEmitterRef<MapLibreEvent & EventData>;
   mapMouseDown: OutputEmitterRef<MapMouseEvent & EventData>;
@@ -99,7 +97,7 @@ export interface MapEvent {
   idle: OutputEmitterRef<MapLibreEvent & EventData>;
 }
 
-export interface LayerEvents {
+export type LayerEvents = {
   layerClick: OutputEmitterRef<MapLayerMouseEvent & EventData>;
   layerDblClick: OutputEmitterRef<MapLayerMouseEvent & EventData>;
   layerMouseDown: OutputEmitterRef<MapLayerMouseEvent & EventData>;
@@ -120,7 +118,7 @@ export interface LayerEvents {
  * to avoid deprecation angular version < 11.0.0 we declared own Coordinates, Position interface
  */
 
-export interface NgxMapLibreGeolocationCoordinates {
+export type NgxMapLibreGeolocationCoordinates = {
   readonly accuracy: number;
   readonly altitude: number | null;
   readonly altitudeAccuracy: number | null;
@@ -130,7 +128,7 @@ export interface NgxMapLibreGeolocationCoordinates {
   readonly speed: number | null;
 }
 
-export interface Position {
+export type Position = {
   coords: NgxMapLibreGeolocationCoordinates;
   target: GeolocateControl;
   timestamp: number;
@@ -144,7 +142,7 @@ export type MapImageData =
   | ImageData
   | ImageBitmap;
 
-export interface MapImageOptions {
+export type MapImageOptions = {
   pixelRatio: number;
   sdf: boolean;
 }

--- a/projects/showcase/src/app/demo/demo-index.component.ts
+++ b/projects/showcase/src/app/demo/demo-index.component.ts
@@ -31,9 +31,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { LayoutToolbarMenuComponent } from '../shared/layout/layout-toolbar-menu.component';
 
-interface RoutesByCategory {
-  [key: string]: Routes;
-}
+type RoutesByCategory = Record<string, Routes>;
 
 @Component({
   templateUrl: './demo-index.component.html',


### PR DESCRIPTION
I changed the eslint rule to switch from interfaces to types.
Also did a small change from `[key:string]: ...` to `Record<...>`.

This doesn't really change anything in the behavior but it is more inline with how the docs are generated.