### PR TITLE
feat: export NgxMapLibreGLImports to simplify standalone imports

### DIFF
--- a/projects/ngx-maplibre-gl/src/lib/ngx-maplibre-gl.module.ts
+++ b/projects/ngx-maplibre-gl/src/lib/ngx-maplibre-gl.module.ts
@@ -27,7 +27,7 @@ import { VectorSourceComponent } from './source/vector-source.component';
 import { VideoSourceComponent } from './source/video-source.component';
 import { SourceDirective } from './source/source.directive';
 
-const componentsAndDirectives = [
+export const NgxMapLibreGLImports = [
   MapComponent,
   LayerComponent,
   DraggableDirective,
@@ -52,11 +52,11 @@ const componentsAndDirectives = [
   ClusterPointDirective,
   MarkersForClustersComponent,
   TerrainControlDirective,
-  SourceDirective
+  SourceDirective,
 ];
 
 @NgModule({
-  imports: [...componentsAndDirectives],
-  exports: [...componentsAndDirectives],
+  imports: [...NgxMapLibreGLImports],
+  exports: [...NgxMapLibreGLImports],
 })
 export class NgxMapLibreGLModule {}


### PR DESCRIPTION
Instead of importing every single standalone component

```ts
import { ChangeDetectionStrategy, Component } from '@angular/core';
import {
  ImageComponent,
  LayerComponent,
  MapComponent,
} from '@maplibre/ngx-maplibre-gl';

@Component({
  selector: 'map',
  imports: [MapComponent, ImageComponent, LayerComponent],
  template: ` ... `,
  changeDetection: ChangeDetectionStrategy.OnPush,
})
export class Map {}
```

This allows to be replaced with, unused components are tree-shaken.

```ts
import { ChangeDetectionStrategy, Component } from '@angular/core';
import { NgxMapLibreGLImports } from '@maplibre/ngx-maplibre-gl';

@Component({
  selector: 'map',
  imports: [NgxMapLibreGLImports],
  template: ` ... `,
  changeDetection: ChangeDetectionStrategy.OnPush,
})
export class Map {}
```