### PR TITLE
fix: improve set worker url

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Or in the global CSS file (called `styles.css` for example in _angular-cli_):
 ### Serve the MapLibre GL JS web worker
 
 MapLibre GL JS v6 is ESM-only and loads its web worker from a separate file at
-runtime. Bundlers cannot rewrite that URL, so every bundler-based app needs a
-one-time `setWorkerUrl()` call — see
+runtime. Bundlers cannot rewrite that URL, so every bundler-based app must point
+MapLibre at it before the first map is created — see
 [`setWorkerUrl()` is bundler-only](https://maplibre.org/maplibre-gl-js/docs/guides/v5-to-v6-migration-guide/#setworkerurl-is-bundler-only).
 Without it **the worker 404s and no tiles render**. Here is the Angular setup.
 
@@ -85,19 +85,30 @@ together, into the same directory:
 ]
 ```
 
-Then point MapLibre at them in your browser entry point (`main.ts`), before
-bootstrapping. Resolving against `document.baseURI` keeps it correct when your app
-is deployed under a sub-path via `--base-href`:
+Then provide the worker URL with `provideMaplibreWorker` in your application config:
 
 ```ts
-import { bootstrapApplication } from '@angular/platform-browser';
+import { ApplicationConfig } from '@angular/core';
+import { provideMaplibreWorker } from '@maplibre/ngx-maplibre-gl';
+
+export const appConfig: ApplicationConfig = {
+  providers: [provideMaplibreWorker('maplibre-gl-worker.mjs')],
+};
+```
+
+The URL is resolved against `document.baseURI`, so it stays correct when your app
+is deployed under a sub-path via `--base-href`. It can also be provided in a
+component's `providers` to scope it to a subtree. The URL is applied lazily, right
+before the first map is created — unlike calling `setWorkerUrl()` in `main.ts`,
+this keeps `maplibre-gl` out of your initial bundle.
+
+If you cannot use the provider, call `setWorkerUrl()` once yourself before the
+first map is created instead:
+
+```ts
 import { setWorkerUrl } from 'maplibre-gl';
-import { appConfig } from './app/app.config';
-import { AppComponent } from './app/app.component';
 
 setWorkerUrl(new URL('maplibre-gl-worker.mjs', document.baseURI).href);
-
-bootstrapApplication(AppComponent, appConfig).catch((err) => console.error(err));
 ```
 
 If you also run browser-based unit tests, do the same in your test setup file. When

--- a/angular.json
+++ b/angular.json
@@ -88,6 +88,11 @@
             "production": {
               "budgets": [
                 {
+                  "type": "initial",
+                  "maximumWarning": "500kB",
+                  "maximumError": "1MB"
+                },
+                {
                   "type": "anyComponentStyle",
                   "maximumWarning": "4kB",
                   "maximumError": "8kB"

--- a/projects/ngx-maplibre-gl/package.json
+++ b/projects/ngx-maplibre-gl/package.json
@@ -19,6 +19,7 @@
     "url": "https://github.com/maplibre/ngx-maplibre-gl/issues"
   },
   "homepage": "https://github.com/maplibre/ngx-maplibre-gl#readme",
+  "sideEffects": false,
   "peerDependencies": {
     "@angular/common": ">= 22.0.0",
     "@angular/core": ">= 22.0.0",

--- a/projects/ngx-maplibre-gl/src/lib/map/map.service.ts
+++ b/projects/ngx-maplibre-gl/src/lib/map/map.service.ts
@@ -122,11 +122,6 @@ export class MapService {
 
   setup(options: SetupMap) {
     if (this.workerUrl) {
-      // MapLibre GL JS v6 loads its worker from a separate file whose URL cannot
-      // be rewritten by bundlers, so it must be set before the map is created.
-      // This runs in the browser only (setup is called from afterNextRender),
-      // so resolving relative URLs against document.baseURI is safe and keeps
-      // deployments under a sub-path (--base-href) working.
       setWorkerUrl(new URL(this.workerUrl, this.document.baseURI).href);
     } else {
       console.warn(

--- a/projects/ngx-maplibre-gl/src/lib/map/map.service.ts
+++ b/projects/ngx-maplibre-gl/src/lib/map/map.service.ts
@@ -1,3 +1,4 @@
+import { DOCUMENT } from '@angular/common';
 import {
   Injectable,
   NgZone,
@@ -40,9 +41,11 @@ import {
   type MapLayerEventType,
   type MissingStyleImageResolver,
   type ProjectionSpecification,
-  type TransformConstrainFunction
+  type TransformConstrainFunction,
+  setWorkerUrl
 } from 'maplibre-gl';
 import { AsyncSubject } from 'rxjs';
+import { MAPLIBRE_WORKER_URL } from './maplibre-worker';
 import type {
   LayerEvents,
   MapEvent,
@@ -101,6 +104,8 @@ export type MovingOptions =
 @Injectable()
 export class MapService {
   private readonly zone = inject(NgZone);
+  private readonly document = inject(DOCUMENT);
+  private readonly workerUrl = inject(MAPLIBRE_WORKER_URL, { optional: true });
 
   mapInstance: MaplibreMap;
   mapEvents: MapEvent;
@@ -116,6 +121,21 @@ export class MapService {
   readonly mapLoaded$ = this.mapLoaded.asObservable();
 
   setup(options: SetupMap) {
+    if (this.workerUrl) {
+      // MapLibre GL JS v6 loads its worker from a separate file whose URL cannot
+      // be rewritten by bundlers, so it must be set before the map is created.
+      // This runs in the browser only (setup is called from afterNextRender),
+      // so resolving relative URLs against document.baseURI is safe and keeps
+      // deployments under a sub-path (--base-href) working.
+      setWorkerUrl(new URL(this.workerUrl, this.document.baseURI).href);
+    } else {
+      console.warn(
+        'ngx-maplibre-gl: MAPLIBRE_WORKER_URL is not provided. ' +
+        'MapLibre GL JS v6 requires a worker URL to function correctly. ' +
+        "Provide it via provideMaplibreWorker('maplibre-gl-worker.mjs') " +
+        'in your application config or component providers.'
+      );
+    }
     // Workaround rollup issue
     this.createMap(options.mapOptions as MapOptions);
     this.hookEvents(options.mapEvents);

--- a/projects/ngx-maplibre-gl/src/lib/map/maplibre-worker.ts
+++ b/projects/ngx-maplibre-gl/src/lib/map/maplibre-worker.ts
@@ -1,0 +1,47 @@
+import { InjectionToken, type Provider } from '@angular/core';
+
+/**
+ * Injection token holding the URL of the MapLibre GL JS web worker script
+ * (`maplibre-gl-worker.mjs`). It is applied with `setWorkerUrl()` right before
+ * a map is created.
+ *
+ * Prefer {@link provideMaplibreWorker} over providing this token directly.
+ *
+ * @category Map Component
+ */
+export const MAPLIBRE_WORKER_URL = new InjectionToken<string>(
+  'ngx-maplibre-gl worker URL',
+);
+
+/**
+ * Provides the URL of the MapLibre GL JS web worker script.
+ *
+ * MapLibre GL JS v6 loads its worker from a separate file at runtime and
+ * bundlers cannot rewrite that URL, so it must be set with `setWorkerUrl()`
+ * before the first map is created — see
+ * [`setWorkerUrl()` is bundler-only](https://maplibre.org/maplibre-gl-js/docs/guides/v5-to-v6-migration-guide/#setworkerurl-is-bundler-only).
+ * Calling `setWorkerUrl()` in `main.ts` statically imports `maplibre-gl` into
+ * the initial bundle; using this provider instead defers the call to the moment
+ * the first `mgl-map` is set up, keeping `maplibre-gl` out of the initial
+ * bundle.
+ *
+ * The worker file (and the `maplibre-gl-shared.mjs` sibling it imports) must be
+ * served at the provided location, e.g. via `assets` in `angular.json`.
+ * Relative URLs are resolved against `document.baseURI`, so deployments under a
+ * sub-path (`--base-href`) keep working.
+ *
+ * Can be used in the application config or in a component's `providers`:
+ *
+ * @example
+ * ```typescript
+ * // app.config.ts
+ * export const appConfig: ApplicationConfig = {
+ *   providers: [provideMaplibreWorker('maplibre-gl-worker.mjs')],
+ * };
+ * ```
+ *
+ * @category Map Component
+ */
+export function provideMaplibreWorker(workerUrl: string): Provider {
+  return { provide: MAPLIBRE_WORKER_URL, useValue: workerUrl };
+}

--- a/projects/ngx-maplibre-gl/src/lib/map/maplibre-worker.ts
+++ b/projects/ngx-maplibre-gl/src/lib/map/maplibre-worker.ts
@@ -1,11 +1,9 @@
 import { InjectionToken, type Provider } from '@angular/core';
 
 /**
- * Injection token holding the URL of the MapLibre GL JS web worker script
- * (`maplibre-gl-worker.mjs`). It is applied with `setWorkerUrl()` right before
- * a map is created.
- *
- * Prefer {@link provideMaplibreWorker} over providing this token directly.
+ * Injection token for the MapLibre GL JS worker URL, applied via `setWorkerUrl()`
+ * before a map is created. Prefer {@link provideMaplibreWorker} over using this
+ * token directly.
  *
  * @category Map Component
  */
@@ -14,23 +12,13 @@ export const MAPLIBRE_WORKER_URL = new InjectionToken<string>(
 );
 
 /**
- * Provides the URL of the MapLibre GL JS web worker script.
+ * Provides the URL of the MapLibre GL JS web worker script
+ * (`maplibre-gl-worker.mjs`). This defers the `setWorkerUrl()` call until the
+ * first `mgl-map` is set up, keeping `maplibre-gl` out of the initial bundle.
  *
- * MapLibre GL JS v6 loads its worker from a separate file at runtime and
- * bundlers cannot rewrite that URL, so it must be set with `setWorkerUrl()`
- * before the first map is created — see
- * [`setWorkerUrl()` is bundler-only](https://maplibre.org/maplibre-gl-js/docs/guides/v5-to-v6-migration-guide/#setworkerurl-is-bundler-only).
- * Calling `setWorkerUrl()` in `main.ts` statically imports `maplibre-gl` into
- * the initial bundle; using this provider instead defers the call to the moment
- * the first `mgl-map` is set up, keeping `maplibre-gl` out of the initial
- * bundle.
- *
- * The worker file (and the `maplibre-gl-shared.mjs` sibling it imports) must be
- * served at the provided location, e.g. via `assets` in `angular.json`.
- * Relative URLs are resolved against `document.baseURI`, so deployments under a
- * sub-path (`--base-href`) keep working.
- *
- * Can be used in the application config or in a component's `providers`:
+ * Relative URLs are resolved against `document.baseURI` so sub-path deployments
+ * (`--base-href`) work. The worker file and `maplibre-gl-shared.mjs` must be
+ * served at that location (typically via `angular.json` `assets`).
  *
  * @example
  * ```typescript
@@ -39,6 +27,8 @@ export const MAPLIBRE_WORKER_URL = new InjectionToken<string>(
  *   providers: [provideMaplibreWorker('maplibre-gl-worker.mjs')],
  * };
  * ```
+ *
+ * @see [setWorkerUrl is bundler-only](https://maplibre.org/maplibre-gl-js/docs/guides/v5-to-v6-migration-guide/#setworkerurl-is-bundler-only)
  *
  * @category Map Component
  */

--- a/projects/ngx-maplibre-gl/src/public_api.ts
+++ b/projects/ngx-maplibre-gl/src/public_api.ts
@@ -31,6 +31,7 @@ export * from './lib/control/globe-control.directive';
 // Expose MapService for ngx-maplibre-gl extensions
 export * from './lib/map/map.service';
 export * from './lib/map/map.component';
+export * from './lib/map/maplibre-worker';
 
 // Expose GeoJSONSourceComponent to access cluster functions
 export * from './lib/source/geojson/geojson-source.component';

--- a/projects/showcase/src/app/app.config.ts
+++ b/projects/showcase/src/app/app.config.ts
@@ -4,14 +4,24 @@ import {
 } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { routes } from './app.routes';
-import { provideHttpClient, withFetch } from '@angular/common/http';
-import { provideClientHydration, withNoIncrementalHydration } from '@angular/platform-browser';
+import { provideHttpClient } from '@angular/common/http';
+import {
+  provideClientHydration,
+  withNoIncrementalHydration,
+} from '@angular/platform-browser';
+import { provideMaplibreWorker } from '@maplibre/ngx-maplibre-gl';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideZonelessChangeDetection(),
     provideRouter(routes),
-    provideHttpClient(withFetch()),
+    provideHttpClient(),
     provideClientHydration(withNoIncrementalHydration()),
+    // MapLibre GL JS v6 loads its worker from a separate file. The worker (and
+    // the `maplibre-gl-shared.mjs` sibling it imports) are copied into the
+    // output via the `assets` entries in angular.json and pointed at here.
+    // Providing the URL instead of calling `setWorkerUrl()` in main.ts keeps
+    // `maplibre-gl` out of the initial bundle.
+    provideMaplibreWorker('maplibre-gl-worker.mjs'),
   ],
 };

--- a/projects/showcase/src/app/app.config.ts
+++ b/projects/showcase/src/app/app.config.ts
@@ -17,11 +17,6 @@ export const appConfig: ApplicationConfig = {
     provideRouter(routes),
     provideHttpClient(),
     provideClientHydration(withNoIncrementalHydration()),
-    // MapLibre GL JS v6 loads its worker from a separate file. The worker (and
-    // the `maplibre-gl-shared.mjs` sibling it imports) are copied into the
-    // output via the `assets` entries in angular.json and pointed at here.
-    // Providing the URL instead of calling `setWorkerUrl()` in main.ts keeps
-    // `maplibre-gl` out of the initial bundle.
     provideMaplibreWorker('maplibre-gl-worker.mjs'),
   ],
 };

--- a/projects/showcase/src/app/demo/stackblitz-edit/templates.ts
+++ b/projects/showcase/src/app/demo/stackblitz-edit/templates.ts
@@ -82,12 +82,12 @@ export const INDEX_HTML = `<!doctype html>
 `;
 
 export const MAIN_TS = `import { bootstrapApplication } from '@angular/platform-browser';
-import { setWorkerUrl } from 'maplibre-gl';
+import { provideMaplibreWorker } from '@maplibre/ngx-maplibre-gl';
 import { ### } from './demo';
 
-setWorkerUrl(new URL('maplibre-gl-worker.mjs', document.baseURI).href);
-
-bootstrapApplication(###).catch((err) => console.error(err));
+bootstrapApplication(###, {
+	providers: [provideMaplibreWorker('maplibre-gl-worker.mjs')],
+}).catch((err) => console.error(err));
 `;
 
 /**

--- a/projects/showcase/src/main.ts
+++ b/projects/showcase/src/main.ts
@@ -1,13 +1,6 @@
 import { bootstrapApplication } from '@angular/platform-browser';
-import { setWorkerUrl } from 'maplibre-gl';
 import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
-
-// MapLibre GL JS v6 loads its worker from a separate file. Bundlers inline
-// `maplibre-gl` itself but cannot rewrite the worker URL, so the worker (and the
-// `maplibre-gl-shared.mjs` sibling it imports) are copied into the output via the
-// `assets` entries in angular.json and pointed at here.
-setWorkerUrl(new URL('maplibre-gl-worker.mjs', document.baseURI).href);
 
 bootstrapApplication(AppComponent, appConfig).catch((err) =>
   console.error(err)


### PR DESCRIPTION
Calling `setWorkerUrl` in `main.ts` adds `maplibre-gl` to the initial bundle and needs to be loaded for every page, even when the MapComponent isn't used.

Initial bundle size with `setWorkerUrl` in `main.ts` - [ERROR] bundle initial exceeded maximum budget. Budget 1.00 MB was not met by 399.87 kB with a total of 1.40 MB.

With `provideMaplibreWorker` initial budget is 426.56 kB.

Move `setWorkerUrl` into `map.service.ts` setup function to lazily apply the URL. Add `provideMaplibreWorker` to set the worker file name in the `app.config.ts`.

Add `sideEffects:false` so barrel imports like `provideMaplibreWorker` are tree-shake