### PR TITLE
add BooleanInput and booleanAttribute transform to boolean inputs

### DIFF
--- a/projects/ngx-maplibre-gl/src/lib/control/attribution-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/attribution-control.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, afterNextRender, inject, input } from '@angular/core';
+import { Directive, afterNextRender, booleanAttribute, inject, input } from '@angular/core';
 import {
   AttributionControl,
   type AttributionControlOptions,
@@ -6,6 +6,7 @@ import {
 import { MapService } from '../map/map.service';
 import { ControlComponent } from './control.component';
 import { keepAvailableObjectValues } from '../shared/utils/functions/object.fn';
+import { BooleanInput } from '../shared/utils/types';
 
 /**
  * `mglAttribution` - an attribution control directive
@@ -26,7 +27,9 @@ export class AttributionControlDirective {
   >(ControlComponent, { host: true });
 
   /** Init input */
-  readonly compact = input<boolean>();
+  readonly compact = input<boolean, BooleanInput>(undefined, {
+    transform: booleanAttribute,
+  });
   /** Init input */
   readonly customAttribution = input<string | string[]>();
 

--- a/projects/ngx-maplibre-gl/src/lib/control/geolocate-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/geolocate-control.directive.ts
@@ -1,6 +1,7 @@
 import {
   Directive,
   afterNextRender,
+  booleanAttribute,
   inject,
   input,
   output,
@@ -14,6 +15,7 @@ import { MapService } from '../map/map.service';
 import { ControlComponent } from './control.component';
 import type { Position } from '../map/map.types';
 import { keepAvailableObjectValues } from '../shared/utils/functions/object.fn';
+import { BooleanInput } from '../shared/utils/types';
 
 /**
  * `mglGeolocate` - a geolocate control directive
@@ -38,9 +40,13 @@ export class GeolocateControlDirective {
   /* Init inputs */
   readonly fitBoundsOptions = input<FitBoundsOptions>();
   /* Init inputs */
-  readonly trackUserLocation = input<boolean>();
+  readonly trackUserLocation = input<boolean, BooleanInput>(undefined, {
+    transform: booleanAttribute,
+  });
   /* Init inputs */
-  readonly showUserLocation = input<boolean>();
+  readonly showUserLocation = input<boolean, BooleanInput>(undefined, {
+    transform: booleanAttribute,
+  });
 
   readonly geolocate = output<Position>();
 

--- a/projects/ngx-maplibre-gl/src/lib/control/navigation-control.directive.ts
+++ b/projects/ngx-maplibre-gl/src/lib/control/navigation-control.directive.ts
@@ -1,8 +1,15 @@
-import { Directive, afterNextRender, inject, input } from '@angular/core';
+import {
+  Directive,
+  afterNextRender,
+  booleanAttribute,
+  inject,
+  input,
+} from '@angular/core';
 import { NavigationControl, type NavigationControlOptions } from 'maplibre-gl';
 import { MapService } from '../map/map.service';
 import { ControlComponent } from './control.component';
 import { keepAvailableObjectValues } from '../shared/utils/functions/object.fn';
+import { BooleanInput } from '../shared/utils/types';
 
 /**
  * `mglNavigation` - a navigation control directive
@@ -23,13 +30,21 @@ export class NavigationControlDirective {
   >(ControlComponent, { host: true });
 
   /* Init inputs */
-  readonly showCompass = input<boolean>();
+  readonly showCompass = input<boolean, BooleanInput>(undefined, {
+    transform: booleanAttribute,
+  });
   /* Init inputs */
-  readonly showZoom = input<boolean>();
+  readonly showZoom = input<boolean, BooleanInput>(undefined, {
+    transform: booleanAttribute,
+  });
   /* Init inputs */
-  readonly visualizePitch = input<boolean>();
+  readonly visualizePitch = input<boolean, BooleanInput>(undefined, {
+    transform: booleanAttribute,
+  });
   /* Init inputs */
-  readonly visualizeRoll = input<boolean>();
+  readonly visualizeRoll = input<boolean, BooleanInput>(undefined, {
+    transform: booleanAttribute,
+  });
 
   constructor() {
     afterNextRender(() => {
@@ -46,7 +61,7 @@ export class NavigationControlDirective {
         this.controlComponent.control = new NavigationControl(options);
         this.mapService.addControl(
           this.controlComponent.control,
-          this.controlComponent.position()
+          this.controlComponent.position(),
         );
       });
     });

--- a/projects/ngx-maplibre-gl/src/lib/layer/layer.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/layer/layer.component.ts
@@ -5,6 +5,7 @@ import {
   OnDestroy,
   OnInit,
   SimpleChanges,
+  booleanAttribute,
   inject,
   input,
   output,
@@ -22,6 +23,7 @@ import { filter, map, startWith, switchMap } from 'rxjs/operators';
 import { MapService, type SetupLayer } from '../map/map.service';
 import type { EventData, LayerEvents } from '../map/map.types';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { BooleanInput } from '../shared/utils/types';
 
 /**
  * `mgl-layer` - a layer component
@@ -72,7 +74,9 @@ export class LayerComponent
    *
    * Init input
    */
-  readonly removeSource = input<boolean>();
+  readonly removeSource = input<boolean, BooleanInput>(undefined, {
+    transform: booleanAttribute,
+  });
 
   readonly filter = input<FilterSpecification>();
   readonly layout = input<LayerSpecification['layout']>();

--- a/projects/ngx-maplibre-gl/src/lib/map/map.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/map/map.component.ts
@@ -6,6 +6,7 @@ import {
   SimpleChanges,
   afterEveryRender,
   afterNextRender,
+  booleanAttribute,
   inject,
   input,
   output,
@@ -38,6 +39,7 @@ import type {
   MapDataEvent,
 } from './map.types';
 import { firstValueFrom } from 'rxjs';
+import { BooleanInput } from '../shared/utils/types';
 
 /**
  * `mgl-map` - The main map component
@@ -219,7 +221,9 @@ export class MapComponent implements OnChanges, OnDestroy, MapEvent {
   // => First value is a alias to bounds input (since mapbox 0.53.0). Subsequents changes are passed to fitBounds
   readonly fitBounds = input<LngLatBoundsLike>();
   readonly fitScreenCoordinates = input<[PointLike, PointLike]>();
-  readonly centerWithPanTo = input<boolean>();
+  readonly centerWithPanTo = input<boolean, BooleanInput>(undefined, {
+    transform: booleanAttribute,
+  });
   readonly panToOptions = input<AnimationOptions>();
   readonly cursorStyle = input<string>();
   /**

--- a/projects/ngx-maplibre-gl/src/lib/marker/marker.component.ts
+++ b/projects/ngx-maplibre-gl/src/lib/marker/marker.component.ts
@@ -8,6 +8,7 @@ import {
   SimpleChanges,
   ViewEncapsulation,
   afterNextRender,
+  booleanAttribute,
   inject,
   input,
   output,
@@ -18,6 +19,7 @@ import type { Marker, MarkerOptions } from 'maplibre-gl';
 import type { LngLatLikeOrPosition } from '../map/map.types';
 import { MapService } from '../map/map.service';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { BooleanInput } from '../shared/utils/types';
 
 /**
  * `mgl-marker` - a marker component
@@ -62,7 +64,9 @@ export class MarkerComponent implements OnChanges, OnInit, OnDestroy {
   readonly feature = input<GeoJSON.Feature<GeoJSON.Point>>();
   readonly lngLat = input<LngLatLikeOrPosition>();
   readonly draggable = input<MarkerOptions['draggable']>();
-  readonly popupShown = input<boolean>();
+  readonly popupShown = input<boolean, BooleanInput>(undefined, {
+    transform: booleanAttribute,
+  });
   readonly className = input<string>();
   readonly pitchAlignment = input<MarkerOptions['pitchAlignment']>();
   readonly rotationAlignment = input<MarkerOptions['rotationAlignment']>();

--- a/projects/ngx-maplibre-gl/src/lib/shared/utils/types.ts
+++ b/projects/ngx-maplibre-gl/src/lib/shared/utils/types.ts
@@ -1,0 +1,1 @@
+export type BooleanInput = string | boolean | null | undefined;

--- a/projects/ngx-maplibre-gl/src/public_api.ts
+++ b/projects/ngx-maplibre-gl/src/public_api.ts
@@ -28,6 +28,9 @@ export * from './lib/markers-for-clusters/markers-for-clusters.component';
 export * from './lib/control/terrain-control.directive';
 export * from './lib/control/globe-control.directive';
 
+// Expose types referenced by public API
+export * from './lib/shared/utils/types';
+
 // Expose MapService for ngx-maplibre-gl extensions
 export * from './lib/map/map.service';
 export * from './lib/map/map.component';


### PR DESCRIPTION
Add `BooleanInput` type and apply `booleanAttribute` transform.
This allows templates usage like follows to set `showCompass` input value to true

```html
<mgl-control mglNavigation showCompass="true" />
<mgl-control mglNavigation [showCompass]="true" />
<mgl-control mglNavigation showCompass />
```